### PR TITLE
implementing class path config loading for Enforcer

### DIFF
--- a/src/main/java/org/casbin/jcasbin/persist/file_adapter/FileAdapter.java
+++ b/src/main/java/org/casbin/jcasbin/persist/file_adapter/FileAdapter.java
@@ -98,10 +98,8 @@ public class FileAdapter implements Adapter {
             fis.close();
         } catch (FileNotFoundException e) {
             e.printStackTrace();
-            throw new Error("policy file not found");
         } catch (IOException e) {
             e.printStackTrace();
-            throw new Error("IO error occurred");
         }
     }
 
@@ -112,7 +110,6 @@ public class FileAdapter implements Adapter {
             fos.close();
         } catch (IOException e) {
             e.printStackTrace();
-            throw new Error("IO error occurred");
         }
     }
 
@@ -121,7 +118,7 @@ public class FileAdapter implements Adapter {
      */
     @Override
     public void addPolicy(String sec, String ptype, List<String> rule) {
-        throw new Error("not implemented");
+        throw new UnsupportedOperationException("not implemented");
     }
 
     /**
@@ -129,7 +126,7 @@ public class FileAdapter implements Adapter {
      */
     @Override
     public void removePolicy(String sec, String ptype, List<String> rule) {
-        throw new Error("not implemented");
+        throw new UnsupportedOperationException("not implemented");
     }
 
     /**
@@ -137,6 +134,7 @@ public class FileAdapter implements Adapter {
      */
     @Override
     public void removeFilteredPolicy(String sec, String ptype, int fieldIndex, String... fieldValues) {
-        throw new Error("not implemented");
+        throw new UnsupportedOperationException("not implemented");
     }
+
 }

--- a/src/main/java/org/casbin/jcasbin/persist/file_adapter/FileAdapter.java
+++ b/src/main/java/org/casbin/jcasbin/persist/file_adapter/FileAdapter.java
@@ -118,7 +118,7 @@ public class FileAdapter implements Adapter {
      */
     @Override
     public void addPolicy(String sec, String ptype, List<String> rule) {
-        throw new UnsupportedOperationException("not implemented");
+        throw new Error("not implemented");
     }
 
     /**
@@ -126,7 +126,7 @@ public class FileAdapter implements Adapter {
      */
     @Override
     public void removePolicy(String sec, String ptype, List<String> rule) {
-        throw new UnsupportedOperationException("not implemented");
+        throw new Error("not implemented");
     }
 
     /**
@@ -134,7 +134,7 @@ public class FileAdapter implements Adapter {
      */
     @Override
     public void removeFilteredPolicy(String sec, String ptype, int fieldIndex, String... fieldValues) {
-        throw new UnsupportedOperationException("not implemented");
+        throw new Error("not implemented");
     }
 
 }

--- a/src/main/java/org/casbin/jcasbin/persist/file_adapter/FileAdapter.java
+++ b/src/main/java/org/casbin/jcasbin/persist/file_adapter/FileAdapter.java
@@ -91,24 +91,14 @@ public class FileAdapter implements Adapter {
 
 
     private void loadPolicyFile(Model model, Helper.loadPolicyLineHandler<String, Model> handler) {
-        FileInputStream fis;
         try {
-            fis = new FileInputStream(filePath);
+            FileInputStream fis = new FileInputStream(filePath);
+            BufferedReader br = new BufferedReader(new InputStreamReader(fis));
+            Util.loadPolicy(br, model, handler);
+            fis.close();
         } catch (FileNotFoundException e) {
             e.printStackTrace();
             throw new Error("policy file not found");
-        }
-        BufferedReader br = new BufferedReader(new InputStreamReader(fis));
-
-        String line;
-        try {
-            while((line = br.readLine()) != null)
-            {
-                handler.accept(line, model);
-            }
-
-            fis.close();
-            br.close();
         } catch (IOException e) {
             e.printStackTrace();
             throw new Error("IO error occurred");

--- a/src/main/java/org/casbin/jcasbin/persist/io/InputStreamAdapter.java
+++ b/src/main/java/org/casbin/jcasbin/persist/io/InputStreamAdapter.java
@@ -1,0 +1,63 @@
+package org.casbin.jcasbin.persist.io;
+
+import org.casbin.jcasbin.model.Model;
+import org.casbin.jcasbin.persist.Adapter;
+import org.casbin.jcasbin.persist.Helper;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.List;
+
+public class InputStreamAdapter implements Adapter {
+
+    private final InputStream is;
+
+    public InputStreamAdapter(InputStream is) {
+        this.is = is;
+    }
+
+    @Override
+    public void loadPolicy(Model model) {
+        loadPolicyFromClassPath(model, Helper::loadPolicyLine);
+    }
+
+    @Override
+    public void savePolicy(Model model) {
+        throw new Error("not implemented");
+    }
+
+    @Override
+    public void addPolicy(String sec, String ptype, List<String> rule) {
+        throw new Error("not implemented");
+    }
+
+    @Override
+    public void removePolicy(String sec, String ptype, List<String> rule) {
+        throw new Error("not implemented");
+    }
+
+    @Override
+    public void removeFilteredPolicy(String sec, String ptype, int fieldIndex, String... fieldValues) {
+        throw new Error("not implemented");
+    }
+
+    private void loadPolicyFromClassPath(Model model, Helper.loadPolicyLineHandler<String, Model> handler) {
+        BufferedReader br = new BufferedReader(new InputStreamReader(is));
+
+        String line;
+        try {
+            while((line = br.readLine()) != null) {
+                handler.accept(line, model);
+            }
+
+            is.close();
+            br.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new Error("IO error occurred");
+        }
+    }
+
+}

--- a/src/main/java/org/casbin/jcasbin/persist/io/InputStreamAdapter.java
+++ b/src/main/java/org/casbin/jcasbin/persist/io/InputStreamAdapter.java
@@ -3,6 +3,7 @@ package org.casbin.jcasbin.persist.io;
 import org.casbin.jcasbin.model.Model;
 import org.casbin.jcasbin.persist.Adapter;
 import org.casbin.jcasbin.persist.Helper;
+import org.casbin.jcasbin.util.Util;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -44,16 +45,10 @@ public class InputStreamAdapter implements Adapter {
     }
 
     private void loadPolicyFromClassPath(Model model, Helper.loadPolicyLineHandler<String, Model> handler) {
-        BufferedReader br = new BufferedReader(new InputStreamReader(is));
-
-        String line;
         try {
-            while((line = br.readLine()) != null) {
-                handler.accept(line, model);
-            }
-
+            BufferedReader br = new BufferedReader(new InputStreamReader(is));
+            Util.loadPolicy(br, model, handler);
             is.close();
-            br.close();
         } catch (IOException e) {
             e.printStackTrace();
             throw new Error("IO error occurred");

--- a/src/main/java/org/casbin/jcasbin/persist/io/InputStreamAdapter.java
+++ b/src/main/java/org/casbin/jcasbin/persist/io/InputStreamAdapter.java
@@ -26,22 +26,22 @@ public class InputStreamAdapter implements Adapter {
 
     @Override
     public void savePolicy(Model model) {
-        throw new Error("not implemented");
+        throw new UnsupportedOperationException("not implemented");
     }
 
     @Override
     public void addPolicy(String sec, String ptype, List<String> rule) {
-        throw new Error("not implemented");
+        throw new UnsupportedOperationException("not implemented");
     }
 
     @Override
     public void removePolicy(String sec, String ptype, List<String> rule) {
-        throw new Error("not implemented");
+        throw new UnsupportedOperationException("not implemented");
     }
 
     @Override
     public void removeFilteredPolicy(String sec, String ptype, int fieldIndex, String... fieldValues) {
-        throw new Error("not implemented");
+        throw new UnsupportedOperationException("not implemented");
     }
 
     private void loadPolicyFromClassPath(Model model, Helper.loadPolicyLineHandler<String, Model> handler) {
@@ -51,7 +51,6 @@ public class InputStreamAdapter implements Adapter {
             is.close();
         } catch (IOException e) {
             e.printStackTrace();
-            throw new Error("IO error occurred");
         }
     }
 

--- a/src/main/java/org/casbin/jcasbin/util/Util.java
+++ b/src/main/java/org/casbin/jcasbin/util/Util.java
@@ -14,6 +14,11 @@
 
 package org.casbin.jcasbin.util;
 
+import org.casbin.jcasbin.model.Model;
+import org.casbin.jcasbin.persist.Helper;
+
+import java.io.BufferedReader;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -200,4 +205,18 @@ public class Util {
         }
         return true;
     }
+
+    public static void loadPolicy(BufferedReader br, Model model, Helper.loadPolicyLineHandler<String, Model> handler) {
+        String line;
+        try {
+            while((line = br.readLine()) != null) {
+                handler.accept(line, model);
+            }
+            br.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new Error("IO error occurred");
+        }
+    }
+
 }

--- a/src/main/java/org/casbin/jcasbin/util/Util.java
+++ b/src/main/java/org/casbin/jcasbin/util/Util.java
@@ -206,17 +206,12 @@ public class Util {
         return true;
     }
 
-    public static void loadPolicy(BufferedReader br, Model model, Helper.loadPolicyLineHandler<String, Model> handler) {
+    public static void loadPolicy(BufferedReader br, Model model, Helper.loadPolicyLineHandler<String, Model> handler) throws IOException {
         String line;
-        try {
-            while((line = br.readLine()) != null) {
-                handler.accept(line, model);
-            }
-            br.close();
-        } catch (IOException e) {
-            e.printStackTrace();
-            throw new Error("IO error occurred");
+        while((line = br.readLine()) != null) {
+            handler.accept(line, model);
         }
+        br.close();
     }
 
 }

--- a/src/test/java/org/casbin/jcasbin/main/EnforcerClasspathConfigLoadingTest.java
+++ b/src/test/java/org/casbin/jcasbin/main/EnforcerClasspathConfigLoadingTest.java
@@ -1,0 +1,58 @@
+package org.casbin.jcasbin.main;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class EnforcerClasspathConfigLoadingTest {
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                { "alice", "/services/data/list", "GET", true },
+                { "bob", "/services/data/list", "GET", true },
+                { "bob", "/services/data/id/xxx", "PUT", true },
+                { "alice", "/services/data/id/xxx", "PUT", false },
+                { "bob", "/services/data/id/xxx", "DELETE", true },
+                { "alice", "/services/data/id/xxx", "DELETE", false },
+        });
+    }
+
+    private static Enforcer enforcer;
+
+    @BeforeClass
+    public static void init() throws IOException {
+        InputStream  modelStream = EnforcerClasspathConfigLoadingTest.class.getClassLoader().getResourceAsStream("authz_model.conf");
+        InputStream policyStream = EnforcerClasspathConfigLoadingTest.class.getClassLoader().getResourceAsStream("authz_policy.csv");
+        enforcer = new Enforcer(modelStream, policyStream);
+        modelStream.close();
+        policyStream.close();
+    }
+
+    private final String user;
+    private final String path;
+    private final String method;
+    private final boolean expectedResult;
+
+    public EnforcerClasspathConfigLoadingTest(String user, String path, String method, boolean expectedResult) {
+        this.user = user;
+        this.path = path;
+        this.method = method;
+        this.expectedResult = expectedResult;
+    }
+
+    @Test
+    public void testLoadConfigFromClasspath() {
+        boolean result = enforcer.enforce(user, path, method);
+        Assert.assertTrue(result == expectedResult);
+    }
+
+}

--- a/src/test/java/org/casbin/jcasbin/main/TestInputStreamAdapter.java
+++ b/src/test/java/org/casbin/jcasbin/main/TestInputStreamAdapter.java
@@ -1,0 +1,45 @@
+package org.casbin.jcasbin.main;
+
+import org.casbin.jcasbin.persist.io.InputStreamAdapter;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class TestInputStreamAdapter {
+
+    private static InputStreamAdapter inputStreamAdapter;
+
+    @BeforeClass
+    public static void init() throws IOException {
+        InputStream policyStream = EnforcerClasspathConfigLoadingTest.class.getClassLoader().getResourceAsStream("authz_policy.csv");
+        inputStreamAdapter = new InputStreamAdapter(policyStream);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testIsAdapterSavePolicy() {
+        inputStreamAdapter.savePolicy(null);
+        Assert.fail("UnsupportedOperationException expected.");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testIsAdapterAddPolicy() {
+        inputStreamAdapter.addPolicy(null, null, null);
+        Assert.fail("UnsupportedOperationException expected.");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testIsAdapterRemovePolicy() {
+        inputStreamAdapter.removePolicy(null, null, null);
+        Assert.fail("UnsupportedOperationException expected.");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testIsAdapterRemoveFilteredPolicy() {
+        inputStreamAdapter.removeFilteredPolicy(null, null, 0, null);
+        Assert.fail("UnsupportedOperationException expected.");
+    }
+
+}

--- a/src/test/resources/authz_model.conf
+++ b/src/test/resources/authz_model.conf
@@ -1,0 +1,14 @@
+[request_definition]
+r = sub, obj, act
+
+[policy_definition]
+p = sub, obj, act
+
+[role_definition]
+g = _, _
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = g(r.sub, p.sub) && keyMatch(r.obj, p.obj) && (r.act == p.act || p.act == "*")

--- a/src/test/resources/authz_policy.csv
+++ b/src/test/resources/authz_policy.csv
@@ -1,0 +1,7 @@
+p, ROLE_USER, /services/data/list, GET
+p, ROLE_ADMIN, /services/data/list, GET
+p, ROLE_ADMIN, /services/data/id/*, PUT
+p, ROLE_ADMIN, /services/data/id/*, DELETE
+g, alice, ROLE_USER
+g, bob, ROLE_USER
+g, bob, ROLE_ADMIN


### PR DESCRIPTION
Signed-off-by: Juraj Veverka <juraj.veverka@pantheon.tech>

Loading of configuration files for Enforcer from classpath is better than reading files from file system.
Reading from file system may fail in some deployment scenarios. Reading configuration files from classpath is very reliable, and very handy for unit testing and microservice deployments.