### PR TITLE
Make model delimiter more lenient to whitespace

### DIFF
--- a/src/main/java/org/casbin/jcasbin/model/Model.java
+++ b/src/main/java/org/casbin/jcasbin/model/Model.java
@@ -14,19 +14,19 @@
 
 package org.casbin.jcasbin.model;
 
+import static org.casbin.jcasbin.util.Util.splitCommaDelimited;
+
 import org.casbin.jcasbin.config.Config;
-import org.casbin.jcasbin.rbac.RoleManager;
 import org.casbin.jcasbin.util.Util;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
  * Model represents the whole access control model.
  */
 public class Model extends Policy {
-    private static Map<String, String> sectionNameMap;
+    private static final Map<String, String> sectionNameMap;
 
     static {
         sectionNameMap = new HashMap<>();
@@ -64,7 +64,7 @@ public class Model extends Policy {
         }
 
         if (sec.equals("r") || sec.equals("p")) {
-            ast.tokens = ast.value.split(", ");
+            ast.tokens = splitCommaDelimited(ast.value);
             for (int i = 0; i < ast.tokens.length; i ++) {
                 ast.tokens[i] = key + "_" + ast.tokens[i];
             }

--- a/src/main/java/org/casbin/jcasbin/persist/Helper.java
+++ b/src/main/java/org/casbin/jcasbin/persist/Helper.java
@@ -14,6 +14,8 @@
 
 package org.casbin.jcasbin.persist;
 
+import static org.casbin.jcasbin.util.Util.splitCommaDelimited;
+
 import org.casbin.jcasbin.model.Model;
 
 import java.util.Arrays;
@@ -32,7 +34,7 @@ public class Helper {
             return;
         }
 
-        String[] tokens = line.split(", ");
+        String[] tokens = splitCommaDelimited(line);
 
         String key = tokens[0];
         String sec = key.substring(0, 1);

--- a/src/main/java/org/casbin/jcasbin/util/Util.java
+++ b/src/main/java/org/casbin/jcasbin/util/Util.java
@@ -96,7 +96,7 @@ public class Util {
         while (m.find()) {
             m.appendReplacement(sb, m.group().replace(".", "_") );
         }
-        
+
         m.appendTail(sb);
         return sb.toString();
     }
@@ -195,6 +195,21 @@ public class Util {
      */
     public static String paramsToString(String[] s) {
         return String.join(", ", s);
+    }
+
+    /**
+     * splitCommaDelimited splits a comma-delimited string into a string array. It assumes that any
+     * number of whitespace might exist before or after the comma and that tokens do not include
+     * whitespace as part of their value.
+     *
+     * @param s the comma-delimited string.
+     * @return the array with the string tokens.
+     */
+    public static String[] splitCommaDelimited(String s) {
+        if (s == null) {
+            return null;
+        }
+        return s.trim().split("\\s*,\\s*");
     }
 
     /**

--- a/src/test/java/org/casbin/jcasbin/main/UtilTest.java
+++ b/src/test/java/org/casbin/jcasbin/main/UtilTest.java
@@ -1,6 +1,8 @@
 package org.casbin.jcasbin.main;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.casbin.jcasbin.util.Util;
 import org.junit.Test;
@@ -31,5 +33,14 @@ public class UtilTest {
     assertEquals("r.act == p.act", Util.removeComments("r.act == p.act###"));
     assertEquals("", Util.removeComments("### comments"));
     assertEquals("r.act == p.act", Util.removeComments("r.act == p.act"));
+  }
+
+  @Test
+  public void testSplitCommaDelimited(){
+    assertNull(Util.splitCommaDelimited(null));
+    assertArrayEquals(new String[]{"a", "b", "c"}, Util.splitCommaDelimited("a,b,c"));
+    assertArrayEquals(new String[]{"a", "b", "c"}, Util.splitCommaDelimited("a, b, c"));
+    assertArrayEquals(new String[]{"a", "b", "c"}, Util.splitCommaDelimited("a ,b ,c"));
+    assertArrayEquals(new String[]{"a", "b", "c"}, Util.splitCommaDelimited("  a,     b   ,c     "));
   }
 }


### PR DESCRIPTION
Currently, there's an expectation to format the model in a specific way,
where every delimiter is `", "`. This rule isn't documented anywhere and
makes the file formatting inflexible and error-prone.

I suggest we make the delimiter a bit more flexible to whitespace around
the comma, so that it allows people to format their model CSV without
breaking the enforcer initialization.

Fix: https://github.com/casbin/jcasbin/issues/53