### PR TITLE
Use a cache for compiling expressions

### DIFF
--- a/src/main/java/org/casbin/jcasbin/main/ManagementEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/ManagementEnforcer.java
@@ -451,6 +451,7 @@ public class ManagementEnforcer extends InternalEnforcer {
         if (autoBuildRoleLinks) {
             buildRoleLinks();
         }
+        aviatorEval = null;
         return ruleAdded;
     }
 
@@ -512,6 +513,7 @@ public class ManagementEnforcer extends InternalEnforcer {
         if (autoBuildRoleLinks) {
             buildRoleLinks();
         }
+        aviatorEval = null;
         return ruleRemoved;
     }
 
@@ -541,6 +543,7 @@ public class ManagementEnforcer extends InternalEnforcer {
         if (autoBuildRoleLinks) {
             buildRoleLinks();
         }
+        aviatorEval = null;
         return ruleRemoved;
     }
 
@@ -552,5 +555,6 @@ public class ManagementEnforcer extends InternalEnforcer {
      */
     public void addFunction(String name, AviatorFunction function) {
         fm.addFunction(name, function);
+        aviatorEval = null;
     }
 }

--- a/src/main/java/org/casbin/jcasbin/model/Model.java
+++ b/src/main/java/org/casbin/jcasbin/model/Model.java
@@ -37,8 +37,15 @@ public class Model extends Policy {
         sectionNameMap.put("m", "matchers");
     }
 
+    // used by CoreEnforcer to detect changes to Model
+    protected int modCount;
+
     public Model() {
         model = new HashMap<>();
+    }
+
+    public int getModCount() {
+        return modCount;
     }
 
     private boolean loadAssertion(Model model, Config cfg, String sec, String key) {
@@ -77,6 +84,7 @@ public class Model extends Policy {
         }
 
         model.get(sec).put(key, ast);
+        modCount++;
         return true;
     }
 


### PR DESCRIPTION
This PR is intended to fix #78 

Expressions are now compiled by reusing the same AviatorEvaluatorInstance. This instance must be reset each time there is a change in FunctionMap or Model. I did this by setting a reference in FunctionsMap and Model to CoreEnforcer. This is not very elegant but I don't see any other simple way to do it, except with a static field but then we would have thread safety issues.

Warning: Policy.model is a public field so I don't know if it modified outside Casbin. In such a case, user must explicitely call resetExpressionEvaluator.

The benchmarks show some nice improvements in performance.

Note: I don't know what is going on with the PR, github shows a lot of fake differences on Model and Policy