### PR TITLE
Identify the request rule being selected from set of provided rules. …

### DIFF
--- a/src/main/java/org/casbin/jcasbin/main/CoreEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/CoreEnforcer.java
@@ -367,11 +367,9 @@ public class CoreEnforcer {
                 List<String> pvals = model.model.get("p").get("p").policy.get(i);
 
                 // Util.logPrint("Policy Rule: " + pvals);
+                // Select the rule based on request size
                 Map<String, Object> parameters = new HashMap<>();
-                for (int j = 0; j < model.model.get("r").get("r").tokens.length; j ++) {
-                    String token = model.model.get("r").get("r").tokens[j];
-                    parameters.put(token, rvals[j]);
-                }
+                getRTokens(parameters, rvals);
                 for (int j = 0; j < model.model.get("p").get("p").tokens.length; j ++) {
                     String token = model.model.get("p").get("p").tokens[j];
                     parameters.put(token, pvals.get(j));
@@ -452,6 +450,17 @@ public class CoreEnforcer {
         Util.logPrint(reqStr.toString());
 
         return result;
+    }
+    
+    private void getRTokens(Map<String, Object> parameters, Object ...rvals) {
+      for(String rKey : model.model.get("r").keySet()) {
+        if(!(rvals.length == model.model.get("r").get(rKey).tokens.length)) { continue; }
+        for (int j = 0; j < model.model.get("r").get(rKey).tokens.length; j ++) {
+          String token = model.model.get("r").get(rKey).tokens[j];
+          parameters.put(token, rvals[j]);
+        }
+   
+      }
     }
 
     public boolean validateEnforce(Object... rvals){

--- a/src/main/java/org/casbin/jcasbin/util/Util.java
+++ b/src/main/java/org/casbin/jcasbin/util/Util.java
@@ -88,7 +88,7 @@ public class Util {
         if (s.startsWith("r") || s.startsWith("p")) {
             s = s.replaceFirst("\\.", "_");
         }
-        String regex = "(\\|| |=|\\)|\\(|&|<|>|,|\\+|-|!|\\*|\\/)(r|p)\\.";
+        String regex = "(\\|| |=|\\)|\\(|&|<|>|,|\\+|-|!|\\*|\\/)(r|p)[0-9]*\\.";
         Pattern p = Pattern.compile(regex);
         Matcher m = p.matcher(s);
         StringBuffer sb = new StringBuffer();


### PR DESCRIPTION
…This code block access over all the provided request and selects with the one matching the actual request token length. Earlier, it was selecting just one rule where this adds flexibility for more set of request rule.

Feature added:
Where multiple request type can be processed based on the length of the request.

```ini
[request_definition]
r = sub, obj, act
r2 = sub, obj, act, eft

[policy_definition]
p = sub, obj, act, eft

[role_definition]
g = _, _

[policy_effect]
e = priority(p.eft) || deny

[matchers]
m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act
```
Signed-off-by: Jatish Khanna <jatish.khanna@gmail.com>