### PR TITLE
fix: Removed repeated section in loadModel and loadModelFromText in Model.java

### DIFF
--- a/src/main/java/org/casbin/jcasbin/model/Model.java
+++ b/src/main/java/org/casbin/jcasbin/model/Model.java
@@ -106,15 +106,11 @@ public class Model extends Policy {
             }
         }
     }
-
-    /**
-     * loadModel loads the model from model CONF file.
-     *
-     * @param path the path of the model file.
+    /*
+     * Helper function for loadModel and loadModelFromText
      */
-    public void loadModel(String path) {
-        Config cfg = Config.newConfig(path);
-
+    
+    private void loadSections(Config cfg) {
         loadSection(this, cfg, "r");
         loadSection(this, cfg, "p");
         loadSection(this, cfg, "e");
@@ -124,19 +120,25 @@ public class Model extends Policy {
     }
 
     /**
+     * loadModel loads the model from model CONF file.
+     *
+     * @param path the path of the model file.
+     */
+    public void loadModel(String path) {
+        Config cfg = Config.newConfig(path);
+        
+        loadSections(cfg);
+    }
+
+    /**
      * loadModelFromText loads the model from the text.
      *
      * @param text the model text.
      */
     public void loadModelFromText(String text) {
         Config cfg = Config.newConfigFromText(text);
-
-        loadSection(this, cfg, "r");
-        loadSection(this, cfg, "p");
-        loadSection(this, cfg, "e");
-        loadSection(this, cfg, "m");
-
-        loadSection(this, cfg, "g");
+        
+        loadSections(cfg);
     }
 
     /**

--- a/src/main/java/org/casbin/jcasbin/model/Model.java
+++ b/src/main/java/org/casbin/jcasbin/model/Model.java
@@ -106,10 +106,12 @@ public class Model extends Policy {
             }
         }
     }
+    
     /*
      * Helper function for loadModel and loadModelFromText
+     * 
+     * @param config the configuration parser
      */
-    
     private void loadSections(Config cfg) {
         loadSection(this, cfg, "r");
         loadSection(this, cfg, "p");


### PR DESCRIPTION
In Model.java, both `loadModel` and `loadModelFromText` functions have code duplication. That section of code can be converted into a single function and that particular function can be called from both the functions. 

I have created `loadSections` function which contains the section of code that is repeated in `loadModel` and `loadModelFromText` functions and then called it from both the functions.