### PR TITLE
fix: use CSV parsing instead of string splitting for built-in file adapter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,11 @@
             <artifactId>janino</artifactId>
             <version>3.1.2</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>1.8</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/src/main/java/org/casbin/jcasbin/persist/Helper.java
+++ b/src/main/java/org/casbin/jcasbin/persist/Helper.java
@@ -14,11 +14,11 @@
 
 package org.casbin.jcasbin.persist;
 
-import static org.casbin.jcasbin.util.Util.splitCommaDelimited;
-
 import org.casbin.jcasbin.model.Model;
 
 import java.util.Arrays;
+
+import static org.casbin.jcasbin.util.Util.splitCommaDelimited;
 
 public class Helper {
     public interface loadPolicyLineHandler<T, U> {

--- a/src/main/java/org/casbin/jcasbin/util/Util.java
+++ b/src/main/java/org/casbin/jcasbin/util/Util.java
@@ -14,9 +14,14 @@
 
 package org.casbin.jcasbin.util;
 
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -199,18 +204,29 @@ public class Util {
     }
 
     /**
-     * splitCommaDelimited splits a comma-delimited string into a string array. It assumes that any
-     * number of whitespace might exist before or after the comma and that tokens do not include
+     * splitCommaDelimited splits a comma-delimited string according to the default processing method of the CSV file
+     * into a string array. It assumes that any number of whitespace might exist before or after the word and that tokens do not include
      * whitespace as part of their value.
      *
-     * @param s the comma-delimited string.
+     * @param s the string.
      * @return the array with the string tokens.
      */
     public static String[] splitCommaDelimited(String s) {
-        if (s == null) {
-            return null;
+        String[] records = null;
+        if (s != null) {
+            try {
+                CSVParser csvParser = CSVFormat.DEFAULT.parse(new StringReader(s));
+                List<CSVRecord> csvRecords = csvParser.getRecords();
+                records = new String[csvRecords.get(0).size()];
+                for (int i = 0; i < csvRecords.get(0).size(); i++) {
+                    records[i] = csvRecords.get(0).get(i).trim();
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+                Util.logPrintfError("CSV parser failed to parse this line:", s);
+            }
         }
-        return s.trim().split("\\s*,\\s*");
+        return records;
     }
 
     /**

--- a/src/test/java/org/casbin/jcasbin/main/EnforcerUnitTest.java
+++ b/src/test/java/org/casbin/jcasbin/main/EnforcerUnitTest.java
@@ -450,7 +450,6 @@ public class EnforcerUnitTest {
         } catch (IOException ex) {
             ex.printStackTrace();
         }
-
     }
 
     @Test

--- a/src/test/java/org/casbin/jcasbin/main/ModelUnitTest.java
+++ b/src/test/java/org/casbin/jcasbin/main/ModelUnitTest.java
@@ -14,14 +14,14 @@
 
 package org.casbin.jcasbin.main;
 
-import static org.casbin.jcasbin.main.TestUtil.testDomainEnforce;
-import static org.casbin.jcasbin.main.TestUtil.testEnforce;
-import static org.casbin.jcasbin.main.TestUtil.testEnforceWithoutUsers;
+import org.casbin.jcasbin.rbac.RoleManager;
+import org.junit.Test;
 
 import java.util.List;
 
-import org.casbin.jcasbin.rbac.RoleManager;
-import org.junit.Test;
+import static org.casbin.jcasbin.main.TestUtil.testDomainEnforce;
+import static org.casbin.jcasbin.main.TestUtil.testEnforce;
+import static org.casbin.jcasbin.main.TestUtil.testEnforceWithoutUsers;
 
 public class ModelUnitTest {
     @Test

--- a/src/test/java/org/casbin/jcasbin/main/SyncedEnforcerUnitTest.java
+++ b/src/test/java/org/casbin/jcasbin/main/SyncedEnforcerUnitTest.java
@@ -427,6 +427,5 @@ public class SyncedEnforcerUnitTest {
         } catch (IOException ex) {
             ex.printStackTrace();
         }
-
     }
 }


### PR DESCRIPTION
Fix: #158 