### PR TITLE
feat: add support for custom function

### DIFF
--- a/examples/abac_rule_custom_function_model.conf
+++ b/examples/abac_rule_custom_function_model.conf
@@ -1,0 +1,11 @@
+[request_definition]
+r = sub, obj, act
+
+[policy_definition]
+p = sub_rule, obj, act
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = eval(p.sub_rule) && r.act == p.act

--- a/examples/abac_rule_custom_function_policy.csv
+++ b/examples/abac_rule_custom_function_policy.csv
@@ -1,0 +1,2 @@
+p, r.sub.name == 'alice' && custom(r.obj), r.obj, GET
+p, r.sub.age >= 18 && custom(r.obj), r.obj, GET

--- a/examples/abac_rule_with_domains_policy.csv
+++ b/examples/abac_rule_with_domains_policy.csv
@@ -1,6 +1,6 @@
-p, r.domain.equals("domain1"), admin, domain1, data1, read
-p, r.domain.equals("domain1"), admin, domain1, data1, write
-p, r.domain.equals("domain2"), admin, domain2, data2, read
-p, r.domain.equals("domain2"), admin, domain2, data2, write
+p, r.domain == 'domain1', admin, domain1, data1, read
+p, r.domain == 'domain1', admin, domain1, data1, write
+p, r.domain == 'domain2', admin, domain2, data2, read
+p, r.domain == 'domain2', admin, domain2, data2, write
 g, alice, admin, domain1
 g, bob, admin, domain2

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
         <dependency>
             <groupId>com.googlecode.aviator</groupId>
             <artifactId>aviator</artifactId>
-            <version>4.1.2</version>
+            <version>5.2.5</version>
         </dependency>
         <dependency>
             <groupId>com.github.seancfoley</groupId>
@@ -211,11 +211,6 @@
             <artifactId>jmh-generator-annprocess</artifactId>
             <version>1.19</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.janino</groupId>
-            <artifactId>janino</artifactId>
-            <version>3.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/src/main/java/org/casbin/jcasbin/main/CoreEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/CoreEnforcer.java
@@ -381,6 +381,7 @@ public class CoreEnforcer {
                     for (AviatorFunction f : functions.values()) {
                         aviatorEval.addFunction(f);
                     }
+                    fm.setAviatorEval(aviatorEval);
 
                     modelModCount = model.getModCount();
                 }
@@ -554,6 +555,7 @@ public class CoreEnforcer {
      */
     public void resetExpressionEvaluator() {
         aviatorEval = null;
+        fm.setAviatorEval(null);
     }
 
     public boolean isAutoNotifyWatcher() {

--- a/src/main/java/org/casbin/jcasbin/main/ManagementEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/ManagementEnforcer.java
@@ -14,12 +14,11 @@
 
 package org.casbin.jcasbin.main;
 
-import com.googlecode.aviator.runtime.type.AviatorFunction;
 import org.casbin.jcasbin.effect.Effect;
 import org.casbin.jcasbin.model.Assertion;
 import org.casbin.jcasbin.util.Util;
+import org.casbin.jcasbin.util.function.CustomFunction;
 
-import java.lang.reflect.Method;
 import java.util.*;
 
 /**
@@ -475,6 +474,7 @@ public class ManagementEnforcer extends InternalEnforcer {
         boolean ruleAdded = addPolicy("g", ptype, params);
 
         aviatorEval = null;
+        fm.setAviatorEval(null);
         return ruleAdded;
     }
 
@@ -534,6 +534,7 @@ public class ManagementEnforcer extends InternalEnforcer {
         boolean ruleRemoved = removePolicy("g", ptype, params);
 
         aviatorEval = null;
+        fm.setAviatorEval(null);
         return ruleRemoved;
     }
 
@@ -561,18 +562,20 @@ public class ManagementEnforcer extends InternalEnforcer {
         boolean ruleRemoved = removeFilteredPolicy("g", ptype, fieldIndex, fieldValues);
 
         aviatorEval = null;
+        fm.setAviatorEval(null);
         return ruleRemoved;
     }
 
     /**
      * addFunction adds a customized function.
      *
-     * @param name the name of the new function.
-     * @param function the function.
+     * @param name the name of the function.
+     * @param function the custom function.
      */
-    public void addFunction(String name, AviatorFunction function) {
+    public void addFunction(String name, CustomFunction function) {
         fm.addFunction(name, function);
         aviatorEval = null;
+        fm.setAviatorEval(null);
     }
 
     /**

--- a/src/main/java/org/casbin/jcasbin/model/FunctionMap.java
+++ b/src/main/java/org/casbin/jcasbin/model/FunctionMap.java
@@ -14,6 +14,7 @@
 
 package org.casbin.jcasbin.model;
 
+import com.googlecode.aviator.AviatorEvaluatorInstance;
 import com.googlecode.aviator.runtime.type.AviatorFunction;
 import org.casbin.jcasbin.util.function.*;
 
@@ -37,6 +38,31 @@ public class FunctionMap {
      */
     public void addFunction(String name, AviatorFunction function) {
         fm.put(name, function);
+    }
+
+    /**
+     * setAviatorEval adds AviatorEvaluatorInstance to the custom function.
+     *
+     * @param name        the name of the custom function.
+     * @param aviatorEval the AviatorEvaluatorInstance object.
+     */
+    public void setAviatorEval(String name, AviatorEvaluatorInstance aviatorEval) {
+        if (fm.containsKey(name) && fm.get(name) instanceof CustomFunction) {
+            ((CustomFunction) fm.get(name)).setAviatorEval(aviatorEval);
+        }
+    }
+
+    /**
+     * setAviatorEval adds AviatorEvaluatorInstance to all the custom function.
+     *
+     * @param aviatorEval the AviatorEvaluatorInstance object.
+     */
+    public void setAviatorEval(AviatorEvaluatorInstance aviatorEval) {
+        for (AviatorFunction function : fm.values()) {
+            if (function instanceof CustomFunction) {
+                ((CustomFunction) function).setAviatorEval(aviatorEval);
+            }
+        }
     }
 
     /**

--- a/src/main/java/org/casbin/jcasbin/util/function/CustomFunction.java
+++ b/src/main/java/org/casbin/jcasbin/util/function/CustomFunction.java
@@ -1,0 +1,47 @@
+// Copyright 2020 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.casbin.jcasbin.util.function;
+
+import com.googlecode.aviator.AviatorEvaluatorInstance;
+import com.googlecode.aviator.runtime.function.AbstractFunction;
+
+import java.util.Map;
+
+/**
+ * @author: shink
+ */
+public abstract class CustomFunction extends AbstractFunction {
+
+    private AviatorEvaluatorInstance aviatorEval;
+
+    public String replaceTargets(String exp, Map<String, Object> env) {
+        for (String key : env.keySet()) {
+            int index;
+            if ((index = key.indexOf('_')) != -1) {
+                String s = key.substring(index + 1);
+                exp = exp.replace("." + s, "_" + s);
+            }
+        }
+        return exp;
+    }
+
+    public AviatorEvaluatorInstance getAviatorEval() {
+        return aviatorEval;
+    }
+
+    public void setAviatorEval(AviatorEvaluatorInstance aviatorEval) {
+        this.aviatorEval = aviatorEval;
+    }
+}

--- a/src/main/java/org/casbin/jcasbin/util/function/EvalFunc.java
+++ b/src/main/java/org/casbin/jcasbin/util/function/EvalFunc.java
@@ -14,7 +14,6 @@
 
 package org.casbin.jcasbin.util.function;
 
-import com.googlecode.aviator.runtime.function.AbstractFunction;
 import com.googlecode.aviator.runtime.function.FunctionUtils;
 import com.googlecode.aviator.runtime.type.AviatorBoolean;
 import com.googlecode.aviator.runtime.type.AviatorObject;
@@ -24,14 +23,17 @@ import java.util.Map;
 
 /**
  * EvalFunc is the wrapper for eval.
- * @author tldyl
- * @since 2020-07-02
+ * It extends CustomFunction, so it can be used in matcher and policy rule.
+ *
+ * @author shink
  */
-public class EvalFunc extends AbstractFunction {
+public class EvalFunc extends CustomFunction {
+
     @Override
     public AviatorObject call(Map<String, Object> env, AviatorObject arg1) {
-        String ev = FunctionUtils.getStringValue(arg1, env);
-        return AviatorBoolean.valueOf(BuiltInFunctions.eval(ev, env));
+        String eval = FunctionUtils.getStringValue(arg1, env);
+        eval = replaceTargets(eval, env);
+        return AviatorBoolean.valueOf(BuiltInFunctions.eval(eval, env, getAviatorEval()));
     }
 
     @Override

--- a/src/test/java/org/casbin/jcasbin/main/AbacAPIUnitTest.java
+++ b/src/test/java/org/casbin/jcasbin/main/AbacAPIUnitTest.java
@@ -52,7 +52,7 @@ public class AbacAPIUnitTest {
         testDomainEnforce(e, "bob", "domain2", "data2", "read", true);
     }
 
-    public static class TestEvalRule { //This class must be static.
+    public static class TestEvalRule {
         private String name;
         private int age;
 

--- a/src/test/java/org/casbin/jcasbin/main/BuiltInFunctionsUnitTest.java
+++ b/src/test/java/org/casbin/jcasbin/main/BuiltInFunctionsUnitTest.java
@@ -14,10 +14,14 @@
 
 package org.casbin.jcasbin.main;
 
+import com.googlecode.aviator.AviatorEvaluator;
+import com.googlecode.aviator.AviatorEvaluatorInstance;
 import org.junit.Test;
-import static org.casbin.jcasbin.main.TestUtil.testGlobMatch;
-import static org.casbin.jcasbin.main.TestUtil.testKeyGet;
-import static org.casbin.jcasbin.main.TestUtil.testKeyGet2;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.casbin.jcasbin.main.TestUtil.*;
 
 public class BuiltInFunctionsUnitTest {
 
@@ -110,5 +114,22 @@ public class BuiltInFunctionsUnitTest {
         testKeyGet2("/alice", "/:id/all", "id", "");
         testKeyGet2("/alice/all", "/:id", "id", "");
         testKeyGet2("/alice/all", "/:/all", "", "");
+    }
+
+    @Test
+    public void testEvalFunc() {
+        AbacAPIUnitTest.TestEvalRule sub = new AbacAPIUnitTest.TestEvalRule("alice", 18);
+        Map<String, Object> env = new HashMap<>();
+        env.put("r_sub", sub);
+
+        testEval("r_sub.age > 0", env, null, true);
+        testEval("r_sub.name == 'alice'", env, null, true);
+        testEval("r_sub.name == 'bob'", env, null, false);
+
+        AviatorEvaluatorInstance aviatorEval = AviatorEvaluator.newInstance();
+        aviatorEval.addFunction(new FunctionTest.CustomFunc());
+        env.put("r_obj", "/test/url1/url2");
+
+        testEval("r_sub.age >= 18 && custom(r_obj)", env, aviatorEval, true);
     }
 }

--- a/src/test/java/org/casbin/jcasbin/main/FunctionTest.java
+++ b/src/test/java/org/casbin/jcasbin/main/FunctionTest.java
@@ -1,0 +1,56 @@
+// Copyright 2020 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.casbin.jcasbin.main;
+
+import com.googlecode.aviator.runtime.function.FunctionUtils;
+import com.googlecode.aviator.runtime.type.AviatorBoolean;
+import com.googlecode.aviator.runtime.type.AviatorObject;
+import org.casbin.jcasbin.util.function.CustomFunction;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static org.casbin.jcasbin.main.TestUtil.testEnforce;
+
+public class FunctionTest {
+
+    @Test
+    public void testCustomFunction() {
+        Enforcer e = new Enforcer("examples/abac_rule_custom_function_model.conf", "examples/abac_rule_custom_function_policy.csv");
+
+        // add a custom function
+        CustomFunc customFunc = new CustomFunc();
+        e.addFunction(customFunc.getName(), customFunc);
+
+        testEnforce(e, new AbacAPIUnitTest.TestEvalRule("alice", 18), "/test/url1/url2/2", "GET", true);
+        testEnforce(e, new AbacAPIUnitTest.TestEvalRule("alice", 18), "/test/2", "GET", false);
+        testEnforce(e, new AbacAPIUnitTest.TestEvalRule("bob", 10), "/test/url1/url2/2", "GET", false);
+    }
+
+    public static class CustomFunc extends CustomFunction {
+        @Override
+        public AviatorObject call(Map<String, Object> env, AviatorObject arg1) {
+            String obj = FunctionUtils.getStringValue(arg1, env);
+            boolean res = Pattern.compile("/*/url1/url2/*", Pattern.CASE_INSENSITIVE).matcher(obj).find();
+            return AviatorBoolean.valueOf(res);
+        }
+
+        @Override
+        public String getName() {
+            return "custom";
+        }
+    }
+}

--- a/src/test/java/org/casbin/jcasbin/main/TestUtil.java
+++ b/src/test/java/org/casbin/jcasbin/main/TestUtil.java
@@ -14,10 +14,12 @@
 
 package org.casbin.jcasbin.main;
 
+import com.googlecode.aviator.AviatorEvaluatorInstance;
 import org.casbin.jcasbin.util.BuiltInFunctions;
 import org.casbin.jcasbin.util.Util;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -175,5 +177,9 @@ public class TestUtil {
 
     static void testKeyGet2(String key1, String key2, String pathVar, String res) {
         assertEquals(res, BuiltInFunctions.keyGet2Func(key1, key2, pathVar));
+    }
+
+    static void testEval(String eval, Map<String, Object> env, AviatorEvaluatorInstance aviatorEval, boolean res) {
+        assertEquals(res, BuiltInFunctions.eval(eval, env, aviatorEval));
     }
 }


### PR DESCRIPTION
Fix: https://github.com/casbin/jcasbin/issues/183

- use `aviator` instead of `janino` to implement the [eval function](https://github.com/shink/jcasbin/blob/41acdc49774a70b11ca4bbb531443638c6f8b55a/src/main/java/org/casbin/jcasbin/util/BuiltInFunctions.java#L370)
- aviator version: 4.1.2 -> 5.2.5 (latest)
- add support for custom function

If the user wants to use a custom function in the policy rule, he can implement it in [this way](https://github.com/shink/jcasbin/blob/60dd34800a6f6f759f120014fbad7b6d9192df16/src/test/java/org/casbin/jcasbin/main/FunctionTest.java#L31).
