### PR TITLE
fix: update getImplicitPermissionsForUser API

### DIFF
--- a/examples/rbac_with_pattern_policy.csv
+++ b/examples/rbac_with_pattern_policy.csv
@@ -11,5 +11,8 @@ g, cathy, pen_admin
 
 g2, /book/*, book_group
 
+g2, /book/:id, book_group
+g2, /pen/:id, pen_group
+
 g2, /book2/{id}, book_group
 g2, /pen2/{id}, pen_group

--- a/src/main/java/org/casbin/jcasbin/exception/CasbinNameNotExistException.java
+++ b/src/main/java/org/casbin/jcasbin/exception/CasbinNameNotExistException.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The casbin Authors. All Rights Reserved.
+// Copyright 2018 The casbin Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,17 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.casbin.jcasbin.main;
+package org.casbin.jcasbin.exception;
 
-import org.junit.Test;
+public class CasbinNameNotExistException extends RuntimeException {
 
-import static org.casbin.jcasbin.main.TestUtil.testDomainEnforce;
-
-public class GroupRoleManagerTest {
-    @Test
-    public void testGroupRoleManager() {
-        Enforcer e = new Enforcer("examples/group_with_domain_model.conf", "examples/group_with_domain_policy.csv");
-        testDomainEnforce(e, "alice", "domain1", "data1", "read", false);
+    public CasbinNameNotExistException(String message) {
+        super(message);
     }
 
 }

--- a/src/main/java/org/casbin/jcasbin/main/InternalEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/InternalEnforcer.java
@@ -14,6 +14,7 @@
 
 package org.casbin.jcasbin.main;
 
+import org.casbin.jcasbin.model.Assertion;
 import org.casbin.jcasbin.model.Model;
 import org.casbin.jcasbin.persist.BatchAdapter;
 import org.casbin.jcasbin.persist.UpdatableAdapter;
@@ -107,7 +108,7 @@ class InternalEnforcer extends CoreEnforcer {
      * @param rules the rules.
      */
     public void buildIncrementalRoleLinks(Model.PolicyOperations op, String ptype, List<List<String>> rules) {
-        model.buildIncrementalRoleLinks(rm, op, "g", ptype, rules);
+        model.buildIncrementalRoleLinks(rmMap, op, "g", ptype, rules);
     }
 
     /**
@@ -300,5 +301,18 @@ class InternalEnforcer extends CoreEnforcer {
         }
 
         return true;
+    }
+
+    int getDomainIndex(String ptype) {
+        Assertion ast = model.model.get("p").get(ptype);
+        String pattern = String.format("%s_dom", ptype);
+        int index = ast.tokens.length;
+        for (int i = 0; i < ast.tokens.length; i++) {
+            if (ast.tokens[i].equals(pattern)) {
+                index = i;
+                break;
+            }
+        }
+        return index;
     }
 }

--- a/src/main/java/org/casbin/jcasbin/main/SyncedEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/SyncedEnforcer.java
@@ -1256,14 +1256,15 @@ public class SyncedEnforcer extends Enforcer {
     /**
      * getPermissionsForUser gets permissions for a user or role.
      *
-     * @param user the user.
+     * @param user   the user.
+     * @param domain the user's domain.
      * @return the permissions, a permission is usually like (obj, act). It is actually the rule without the subject.
      */
     @Override
-    public List<List<String>> getPermissionsForUser(String user) {
+    public List<List<String>> getPermissionsForUser(String user, String... domain) {
         try {
             READ_WRITE_LOCK.readLock().lock();
-            return super.getPermissionsForUser(user);
+            return super.getPermissionsForUser(user, domain);
         } finally {
             READ_WRITE_LOCK.readLock().unlock();
         }
@@ -1427,14 +1428,15 @@ public class SyncedEnforcer extends Enforcer {
      * getPermissionsForUser("alice") can only get: [["alice", "data2", "read"]].
      * But getImplicitPermissionsForUser("alice") will get: [["admin", "data1", "read"], ["alice", "data2", "read"]].
      *
-     * @param user the user.
+     * @param user   the user.
+     * @param domain the user's domain.
      * @return implicit permissions for a user or role.
      */
     @Override
-    public List<List<String>> getImplicitPermissionsForUser(String user) {
+    public List<List<String>> getImplicitPermissionsForUser(String user, String... domain) {
         try {
             READ_WRITE_LOCK.readLock().lock();
-            return super.getImplicitPermissionsForUser(user);
+            return super.getImplicitPermissionsForUser(user, domain);
         } finally {
             READ_WRITE_LOCK.readLock().unlock();
         }

--- a/src/main/java/org/casbin/jcasbin/model/Policy.java
+++ b/src/main/java/org/casbin/jcasbin/model/Policy.java
@@ -30,11 +30,14 @@ public class Policy {
     /**
      * buildRoleLinks initializes the roles in RBAC.
      *
-     * @param rm the role manager.
+     * @param rmMap the role manager map.
      */
-    public void buildRoleLinks(RoleManager rm) {
+    public void buildRoleLinks(Map<String, RoleManager> rmMap) {
         if (model.containsKey("g")) {
-            for (Assertion ast : model.get("g").values()) {
+            for (Map.Entry<String, Assertion> entry : model.get("g").entrySet()) {
+                String ptype = entry.getKey();
+                Assertion ast = entry.getValue();
+                RoleManager rm = rmMap.get(ptype);
                 ast.buildRoleLinks(rm);
             }
         }
@@ -136,9 +139,9 @@ public class Policy {
 
         for (List<String> rule : model.get(sec).get(ptype).policy) {
             boolean matched = true;
-            for (int i = 0; i < fieldValues.length; i ++) {
+            for (int i = 0; i < fieldValues.length; i++) {
                 String fieldValue = fieldValues[i];
-                if (!fieldValue.equals("") && !rule.get(fieldIndex + i).equals(fieldValue)) {
+                if (fieldValue != null && !"".equals(fieldValue) && !rule.get(fieldIndex + i).equals(fieldValue)) {
                     matched = false;
                     break;
                 }
@@ -359,9 +362,9 @@ public class Policy {
         return values;
     }
 
-    public void buildIncrementalRoleLinks(RoleManager rm, Model.PolicyOperations op, String sec, String ptype, List<List<String>> rules) {
-        if (sec.equals("g")) {
-            model.get(sec).get(ptype).buildIncrementalRoleLinks(rm, op, rules);
+    public void buildIncrementalRoleLinks(Map<String, RoleManager> rmMap, Model.PolicyOperations op, String sec, String ptype, List<List<String>> rules) {
+        if ("g".equals(sec)) {
+            model.get(sec).get(ptype).buildIncrementalRoleLinks(rmMap.get(ptype), op, rules);
         }
     }
 

--- a/src/main/java/org/casbin/jcasbin/rbac/DefaultRoleManager.java
+++ b/src/main/java/org/casbin/jcasbin/rbac/DefaultRoleManager.java
@@ -14,10 +14,11 @@
 
 package org.casbin.jcasbin.rbac;
 
+import org.casbin.jcasbin.exception.CasbinNameNotExistException;
+import org.casbin.jcasbin.util.Util;
+
 import java.util.*;
 import java.util.function.BiPredicate;
-
-import org.casbin.jcasbin.util.Util;
 
 public class DefaultRoleManager implements RoleManager {
     private static String defaultDomain = "casbin::default";
@@ -159,7 +160,7 @@ public class DefaultRoleManager implements RoleManager {
         final DomainRoles allRoles = getOrCreateDomainRoles(domainName(domain));
 
         if (!allRoles.hasRole(name1) || !allRoles.hasRole(name2)) {
-            throw new IllegalArgumentException("error: name1 or name2 does not exist");
+            throw new CasbinNameNotExistException("error: name1 or name2 does not exist");
         }
 
         final Role role1 = allRoles.getOrCreate(name1);
@@ -229,8 +230,8 @@ public class DefaultRoleManager implements RoleManager {
 
         final DomainRoles allRoles = getMatchingDomainRoles(domain);
 
-        if (!allRoles.hasRole(name, domainMatchingFunc)) {
-            throw new IllegalArgumentException("error: name does not exist");
+        if (!allRoles.hasRole(name, matchingFunc)) {
+            throw new CasbinNameNotExistException("error: name does not exist");
         }
 
         final List<String> names = new ArrayList<>();

--- a/src/test/java/org/casbin/jcasbin/main/RbacAPIUnitTest.java
+++ b/src/test/java/org/casbin/jcasbin/main/RbacAPIUnitTest.java
@@ -14,11 +14,16 @@
 
 package org.casbin.jcasbin.main;
 
+import org.casbin.jcasbin.util.Util;
 import org.junit.Test;
+
+import java.util.Comparator;
+import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.casbin.jcasbin.main.TestUtil.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class RbacAPIUnitTest {
     @Test
@@ -147,5 +152,27 @@ public class RbacAPIUnitTest {
                 )
         );
 
+    }
+
+    private void testGetImplicitUsersForRole(Enforcer e, String name, List<String> res) {
+        List<String> myRes = e.getImplicitUsersForRole(name);
+        Comparator<String> comparator = String::compareTo;
+        myRes.sort(comparator);
+        res.sort(comparator);
+
+        if (!Util.arrayEquals(res, myRes)) {
+            fail("Implicit users for : " + name + ": " + myRes + ", supposed to be " + res);
+        }
+    }
+
+    @Test
+    public void testImplicitUsersForRole() {
+        Enforcer e = new Enforcer("examples/rbac_with_pattern_model.conf", "examples/rbac_with_pattern_policy.csv");
+
+        testGetImplicitUsersForRole(e, "book_admin", asList("alice"));
+        testGetImplicitUsersForRole(e, "pen_admin", asList("cathy", "bob"));
+
+        testGetImplicitUsersForRole(e, "book_group", asList("/book/*", "/book/:id", "/book2/{id}"));
+        testGetImplicitUsersForRole(e, "pen_group", asList("/pen/:id", "/pen2/{id}"));
     }
 }

--- a/src/test/java/org/casbin/jcasbin/main/RbacAPIWithPatternMatchUnitTest.java
+++ b/src/test/java/org/casbin/jcasbin/main/RbacAPIWithPatternMatchUnitTest.java
@@ -14,16 +14,13 @@
 
 package org.casbin.jcasbin.main;
 
-import static java.util.Arrays.asList;
-import static org.casbin.jcasbin.main.TestUtil.testDomainEnforce;
-import static org.casbin.jcasbin.main.TestUtil.testEnforce;
-import static org.casbin.jcasbin.main.TestUtil.testGetImplicitPermissionsInDomain;
-import static org.casbin.jcasbin.main.TestUtil.testGetRolesInDomain;
-
 import org.casbin.jcasbin.persist.file_adapter.FileAdapter;
 import org.casbin.jcasbin.rbac.DefaultRoleManager;
 import org.casbin.jcasbin.util.BuiltInFunctions;
 import org.junit.Test;
+
+import static java.util.Arrays.asList;
+import static org.casbin.jcasbin.main.TestUtil.*;
 
 public class RbacAPIWithPatternMatchUnitTest {
 
@@ -31,7 +28,7 @@ public class RbacAPIWithPatternMatchUnitTest {
     public void testEnforceAPIWithKeyMatch3Pattern() {
         final Enforcer e = new Enforcer("examples/rbac_with_pattern_model.conf");
         e.setAdapter(new FileAdapter("examples/rbac_with_pattern_policy.csv"));
-        e.setRoleManager(new DefaultRoleManager(10, BuiltInFunctions::keyMatch3, null));
+        e.setRoleManager("g2", new DefaultRoleManager(10, BuiltInFunctions::keyMatch3, null));
         e.loadPolicy();
 
         testEnforce(e, "alice", "/book/1", "GET", true);

--- a/src/test/java/org/casbin/jcasbin/main/TestUtil.java
+++ b/src/test/java/org/casbin/jcasbin/main/TestUtil.java
@@ -159,7 +159,7 @@ public class TestUtil {
     }
 
     static void testGetImplicitPermissionsInDomain(Enforcer e, String name, String domain, List<List<String>> res) {
-        List<List<String>> myRes = e.getImplicitPermissionsForUserInDomain(name, domain);
+        List<List<String>> myRes = e.getImplicitPermissionsForUser(name, domain);
         Util.logPrint("Permissions for " + name + " under " + domain + ": " + myRes);
 
         if (!Util.array2DEquals(res, myRes)) {


### PR DESCRIPTION
Fix: #174

- use `rmMap` to build a role manager for every group.

> Then, you can custom role manager for every group, such as [testEnforceAPIWithKeyMatch3Pattern()](https://github.com/shink/jcasbin/blob/9c5c08e26a6bf4fc1c1a0b3ed6e81098466536dc/src/test/java/org/casbin/jcasbin/main/RbacAPIWithPatternMatchUnitTest.java#L31).

- update `getPermissionsForUser()`, `getImplicitRolesForUser()`, `getImplicitUsersForRole()`, `getImplicitPermissionsForUser()`
- fix test bug in `testGroupRoleManager()`