### PR TITLE
update dependency in the readme to version 1.8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ For Maven:
 <dependency>
   <groupId>org.casbin</groupId>
   <artifactId>jcasbin</artifactId>
-  <version>1.6.3</version>
+  <version>1.8.3</version>
 </dependency>
 ```
 


### PR DESCRIPTION
i actually spend an hour on so using the 1.6.3 version mentioned in the  readme, and i was wondering why the explicit priority model wasn't working, turned out this was an older verison, so i updated the version in the readme so anyone following the readme use the newer version