### PR TITLE
fix: 'in' operator causes the expression to lose content

### DIFF
--- a/src/main/java/org/casbin/jcasbin/util/Util.java
+++ b/src/main/java/org/casbin/jcasbin/util/Util.java
@@ -117,12 +117,13 @@ public class Util {
         String reg = "([a-zA-Z0-9_.()\"]*) +in +([a-zA-Z0-9_.()\"]*)";
         Matcher m1 = Pattern.compile(reg).matcher(expString);
         StringBuffer sb = new StringBuffer();
-        boolean flag=false;
+        boolean flag = false;
         while (m1.find()) {
-            flag=true;
-            m1.appendReplacement(sb,"include($2, $1)");
+            flag = true;
+            m1.appendReplacement(sb, "include($2, $1)");
         }
-        return flag?sb.toString():expString;
+        m1.appendTail(sb);
+        return flag ? sb.toString() : expString;
     }
     /**
      * removeComments removes the comments starting with # in the text.

--- a/src/test/java/org/casbin/jcasbin/main/UtilTest.java
+++ b/src/test/java/org/casbin/jcasbin/main/UtilTest.java
@@ -45,6 +45,7 @@ public class UtilTest {
         assertEquals("include(r_obj, r_sub)", Util.convertInSyntax("r_sub in r_obj"));
         assertEquals("include(r_obj, r_sub.name)", Util.convertInSyntax("r_sub.name in r_obj"));
         assertEquals("include(r_obj.name, r_sub.name)", Util.convertInSyntax("r_sub.name in r_obj.name"));
+        assertEquals("include(r_obj, r_sub) && r.obj == p.obj", Util.convertInSyntax("r_sub in r_obj && r.obj == p.obj"));
     }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Yixiang Zhao <seriouszyx@foxmail.com>

Fix: https://github.com/casbin/jcasbin/issues/252 

Fix the bug and add a unit test.

Before -->

![image](https://user-images.githubusercontent.com/33992371/151135601-d2aeeb06-4367-4aac-8478-2ff7d7476298.png)

After --> Tests passed.

