### PR TITLE
fix: optimize the deleteRole method

### DIFF
--- a/src/main/java/org/casbin/jcasbin/rbac/Role.java
+++ b/src/main/java/org/casbin/jcasbin/rbac/Role.java
@@ -44,13 +44,12 @@ class Role {
     }
 
     void deleteRole(Role role) {
-        List<Role> toRemove = new ArrayList<>();
         for (Role r : roles) {
             if (r.name.equals(role.name)) {
-                toRemove.add(r);
+                roles.remove(r);
+                return;
             }
         }
-        roles.removeAll(toRemove);
     }
 
     boolean hasRole(String name, int hierarchyLevel) {
@@ -83,7 +82,7 @@ class Role {
             if (i == 0) {
                 names.append(role.name);
             } else {
-                names.append(", " + role.name);
+                names.append(", ").append(role.name);
             }
         }
         return name + " < " + names;


### PR DESCRIPTION
Signed-off-by: imp2002 <imp07@qq.com>

![image](https://user-images.githubusercontent.com/41513919/167650607-ac236d6b-46ca-4472-a016-d2cc552489ca.png)

Role is not repeated, so when delete a role, there will be no more roles that need to be deleted, 
the function should over.