### PR TITLE
fix: DistributedEnforcer addPolicySelf and InternalEnforcer to use dispatcher in methods

### DIFF
--- a/src/main/java/org/casbin/jcasbin/main/CoreEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/CoreEnforcer.java
@@ -710,7 +710,7 @@ public class CoreEnforcer {
         this.autoNotifyDispatcher = autoNotifyDispatcher;
     }
 
-    public boolean mustUseDispatcher() {
+    protected boolean mustUseDispatcher() {
        return this.dispatcher != null && this.autoNotifyDispatcher;
     }
 }

--- a/src/main/java/org/casbin/jcasbin/main/CoreEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/CoreEnforcer.java
@@ -709,4 +709,8 @@ public class CoreEnforcer {
     public void setAutoNotifyDispatcher(boolean autoNotifyDispatcher) {
         this.autoNotifyDispatcher = autoNotifyDispatcher;
     }
+
+    public boolean mustUseDispatcher() {
+       return this.dispatcher != null && this.autoNotifyDispatcher;
+    }
 }

--- a/src/main/java/org/casbin/jcasbin/main/DistributedEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/DistributedEnforcer.java
@@ -110,7 +110,7 @@ public class DistributedEnforcer extends SyncedEnforcer {
     public List<List<String>> addPolicySelf(BooleanSupplier shouldPersist, String sec, String ptype, List<List<String>> rules) {
         List<List<String>> noExistsPolicy = new ArrayList<>();
         for (List<String> rule : rules) {
-            if (this.model.hasPolicy(sec, ptype, rule)) {
+            if (!this.model.hasPolicy(sec, ptype, rule)) {
                 noExistsPolicy.add(rule);
             }
         }

--- a/src/main/java/org/casbin/jcasbin/main/InternalEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/InternalEnforcer.java
@@ -36,9 +36,7 @@ class InternalEnforcer extends CoreEnforcer {
      */
     boolean addPolicy(String sec, String ptype, List<String> rule) {
         if (mustUseDispatcher()) {
-            List<List<String>> rules = new ArrayList<>();
-            rules.add(rule);
-            dispatcher.addPolicies(sec, ptype, rules);
+            dispatcher.addPolicies(sec, ptype, singletonList(rule));
             return true;
         }
 
@@ -124,9 +122,7 @@ class InternalEnforcer extends CoreEnforcer {
      */
     boolean removePolicy(String sec, String ptype, List<String> rule) {
         if (mustUseDispatcher()) {
-            List<List<String>> rules = new ArrayList<>();
-            rules.add(rule);
-            dispatcher.removePolicies(sec, ptype, rules);
+            dispatcher.removePolicies(sec, ptype, singletonList(rule));
             return true;
         }
 
@@ -339,7 +335,7 @@ class InternalEnforcer extends CoreEnforcer {
         final List<List<String>> rules,
         final Model.PolicyOperations operation
     ) {
-        if (sec.equals("g")) {
+        if ("g".equals(sec)) {
             buildIncrementalRoleLinks(operation, ptype, rules);
         }
     }

--- a/src/main/java/org/casbin/jcasbin/main/InternalEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/InternalEnforcer.java
@@ -33,6 +33,13 @@ class InternalEnforcer extends CoreEnforcer {
      * addPolicy adds a rule to the current policy.
      */
     boolean addPolicy(String sec, String ptype, List<String> rule) {
+        if (mustUseDispatcher()) {
+            List<List<String>> rules = new ArrayList<>();
+            rules.add(rule);
+            dispatcher.addPolicies(sec, ptype, rules);
+            return true;
+        }
+
         if (model.hasPolicy(sec, ptype, rule)) {
             return false;
         }
@@ -71,6 +78,11 @@ class InternalEnforcer extends CoreEnforcer {
      * addPolicies adds rules to the current policy.
      */
     boolean addPolicies(String sec, String ptype, List<List<String>> rules) {
+        if (mustUseDispatcher()) {
+            dispatcher.addPolicies(sec, ptype, rules);
+            return true;
+        }
+
         if (model.hasPolicies(sec, ptype, rules)) {
             return false;
         }
@@ -115,6 +127,13 @@ class InternalEnforcer extends CoreEnforcer {
      * removePolicy removes a rule from the current policy.
      */
     boolean removePolicy(String sec, String ptype, List<String> rule) {
+        if (mustUseDispatcher()) {
+            List<List<String>> rules = new ArrayList<>();
+            rules.add(rule);
+            dispatcher.removePolicies(sec, ptype, rules);
+            return true;
+        }
+
         if (adapter != null && autoSave) {
             try {
                 adapter.removePolicy(sec, ptype, rule);
@@ -159,7 +178,7 @@ class InternalEnforcer extends CoreEnforcer {
      * @return succeeds or not.
      */
     boolean updatePolicy(String sec, String ptype, List<String> oldRule, List<String> newRule) {
-        if (dispatcher != null && autoNotifyDispatcher) {
+        if (mustUseDispatcher()) {
             dispatcher.updatePolicy(sec, ptype, oldRule, newRule);
             return true;
         }
@@ -225,6 +244,11 @@ class InternalEnforcer extends CoreEnforcer {
      * removePolicies removes rules from the current policy.
      */
     boolean removePolicies(String sec, String ptype, List<List<String>> rules) {
+        if (mustUseDispatcher()) {
+            dispatcher.removePolicies(sec, ptype, rules);
+            return true;
+        }
+
         if (!model.hasPolicies(sec, ptype, rules)) {
             return false;
         }
@@ -264,8 +288,13 @@ class InternalEnforcer extends CoreEnforcer {
      * removeFilteredPolicy removes rules based on field filters from the current policy.
      */
     boolean removeFilteredPolicy(String sec, String ptype, int fieldIndex, String... fieldValues) {
+        if (mustUseDispatcher()) {
+            dispatcher.removeFilteredPolicy(sec, ptype, fieldIndex, fieldValues);
+            return true;
+        }
+
         if (fieldValues == null || fieldValues.length == 0) {
-            Util.logPrint("Invaild fieldValues parameter");
+            Util.logPrint("Invalid fieldValues parameter");
             return false;
         }
 

--- a/src/main/java/org/casbin/jcasbin/main/InternalEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/InternalEnforcer.java
@@ -25,6 +25,8 @@ import org.casbin.jcasbin.util.Util;
 import java.util.ArrayList;
 import java.util.List;
 
+import static java.util.Collections.singletonList;
+
 /**
  * InternalEnforcer = CoreEnforcer + Internal API.
  */
@@ -57,11 +59,7 @@ class InternalEnforcer extends CoreEnforcer {
 
         model.addPolicy(sec, ptype, rule);
 
-        if (sec.equals("g")) {
-            List<List<String>> rules = new ArrayList<>();
-            rules.add(rule);
-            buildIncrementalRoleLinks(Model.PolicyOperations.POLICY_ADD, ptype, rules);
-        }
+        buildIncrementalRoleLinks(sec, ptype, singletonList(rule), Model.PolicyOperations.POLICY_ADD);
 
         if (watcher != null && autoNotifyWatcher) {
             if (watcher instanceof WatcherEx) {
@@ -102,9 +100,7 @@ class InternalEnforcer extends CoreEnforcer {
 
         model.addPolicies(sec, ptype, rules);
 
-        if (sec.equals("g")) {
-            buildIncrementalRoleLinks(Model.PolicyOperations.POLICY_ADD, ptype, rules);
-        }
+        buildIncrementalRoleLinks(sec, ptype, rules, Model.PolicyOperations.POLICY_ADD);
 
         if (watcher != null && autoNotifyWatcher) {
             watcher.update();
@@ -151,11 +147,7 @@ class InternalEnforcer extends CoreEnforcer {
             return false;
         }
 
-        if (sec.equals("g")) {
-            List<List<String>> rules = new ArrayList<>();
-            rules.add(rule);
-            buildIncrementalRoleLinks(Model.PolicyOperations.POLICY_REMOVE, ptype, rules);
-        }
+        buildIncrementalRoleLinks(sec, ptype, singletonList(rule), Model.PolicyOperations.POLICY_REMOVE);
 
         if (watcher != null && autoNotifyWatcher) {
             if (watcher instanceof WatcherEx) {
@@ -272,9 +264,7 @@ class InternalEnforcer extends CoreEnforcer {
             return false;
         }
 
-        if (sec.equals("g")) {
-            buildIncrementalRoleLinks(Model.PolicyOperations.POLICY_REMOVE, ptype, rules);
-        }
+        buildIncrementalRoleLinks(sec, ptype, rules, Model.PolicyOperations.POLICY_REMOVE);
 
         if (watcher != null && autoNotifyWatcher) {
             // error intentionally ignored
@@ -316,9 +306,7 @@ class InternalEnforcer extends CoreEnforcer {
             return false;
         }
 
-        if (sec.equals("g")) {
-            buildIncrementalRoleLinks(Model.PolicyOperations.POLICY_REMOVE, ptype, effects);
-        }
+        buildIncrementalRoleLinks(sec, ptype, effects, Model.PolicyOperations.POLICY_REMOVE);
 
         if (watcher != null && autoNotifyWatcher) {
             // error intentionally ignored
@@ -344,4 +332,16 @@ class InternalEnforcer extends CoreEnforcer {
         }
         return index;
     }
+
+    private void buildIncrementalRoleLinks(
+        final String sec,
+        final String ptype,
+        final List<List<String>> rules,
+        final Model.PolicyOperations operation
+    ) {
+        if (sec.equals("g")) {
+            buildIncrementalRoleLinks(operation, ptype, rules);
+        }
+    }
+
 }

--- a/src/test/java/org/casbin/jcasbin/main/InternalEnforcerWithDispatcherTest.java
+++ b/src/test/java/org/casbin/jcasbin/main/InternalEnforcerWithDispatcherTest.java
@@ -1,0 +1,130 @@
+package org.casbin.jcasbin.main;
+
+import org.casbin.jcasbin.persist.Dispatcher;
+import org.junit.Before;
+import org.junit.Test;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class InternalEnforcerWithDispatcherTest {
+
+    private final static String SEC = "expected-sec";
+
+    private final static String PTYPE = "expected-ptype";
+
+    private final static List<String> RULE = asList("expected-new-rule-1", "expected-new-rule-2");
+
+    private final static List<String> OLD_RULE = asList("expected-old-rule-1", "expected-old-rule-2");
+
+    private final static int FIELD_INDEX = 0;
+
+    private final static String[] FIELD_VALUES = new String[1];
+
+    private InternalEnforcer enforcer;
+
+    @Before
+    public void setUp() {
+        this.enforcer = new InternalEnforcer();
+        this.enforcer.setDispatcher(new CustomDispatcher());
+        this.enforcer.setAutoNotifyDispatcher(true);
+    }
+
+    @Test
+    public void testAddPolicy() {
+        boolean result = enforcer.addPolicy(SEC, PTYPE, RULE);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testAddPolicies() {
+        boolean result = enforcer.addPolicies(SEC, PTYPE, singletonList(RULE));
+        assertTrue(result);
+    }
+
+    @Test
+    public void testRemovePolicy() {
+        boolean result = enforcer.removePolicy(SEC, PTYPE, RULE);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testRemovePolicies() {
+        boolean result = enforcer.removePolicies(SEC, PTYPE, singletonList(RULE));
+        assertTrue(result);
+    }
+
+    @Test
+    public void testRemoveFilteredPolicy() {
+        boolean result = enforcer.removeFilteredPolicy(SEC, PTYPE, FIELD_INDEX, FIELD_VALUES);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testUpdatePolicy() {
+        boolean result = enforcer.updatePolicy(SEC, PTYPE, OLD_RULE, RULE);
+        assertTrue(result);
+    }
+
+    private static class CustomDispatcher implements Dispatcher {
+
+        @Override
+        public void addPolicies(
+            final String sec,
+            final String ptype,
+            final List<List<String>> rules
+        ) {
+            assertEquals(SEC, sec);
+            assertEquals(PTYPE, ptype);
+            assertEquals(singletonList(RULE), rules);
+        }
+
+        @Override
+        public void removePolicies(
+            final String sec,
+            final String ptype,
+            final List<List<String>> rules
+        ) {
+            assertEquals(SEC, sec);
+            assertEquals(PTYPE, ptype);
+            assertEquals(singletonList(RULE), rules);
+        }
+
+        @Override
+        public void removeFilteredPolicy(
+            final String sec,
+            final String ptype,
+            final int fieldIndex,
+            final String... fieldValues
+        ) {
+            assertEquals(SEC, sec);
+            assertEquals(PTYPE, ptype);
+            assertEquals(FIELD_INDEX, fieldIndex);
+            assertArrayEquals(FIELD_VALUES, fieldValues);
+        }
+
+        @Override
+        public void clearPolicy() {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public void updatePolicy(
+            final String sec,
+            final String ptype,
+            final List<String> oldRule,
+            final List<String> newRule
+        ) {
+            assertEquals(SEC, sec);
+            assertEquals(PTYPE, ptype);
+            assertEquals(OLD_RULE, oldRule);
+            assertEquals(RULE, newRule);
+        }
+    }
+}

--- a/src/test/java/org/casbin/jcasbin/main/SyncedDistributedAPIUnitTest.java
+++ b/src/test/java/org/casbin/jcasbin/main/SyncedDistributedAPIUnitTest.java
@@ -30,7 +30,10 @@ public class SyncedDistributedAPIUnitTest {
             asList("bob", "data2", "write"),
             asList("data2_admin", "data2", "read"),
             asList("data2_admin", "data2", "write")));
-        de.addPolicySelf(() -> false, "g", "g", asList(asList("alice", "data2_admin")));
+        de.addPolicySelf(() -> false, "g", "g", asList(
+            asList("alice", "data2_admin"),
+            asList("new_user", "data2_admin")
+        ));
 
         testEnforce(de, "alice", "data1", "read", true);
         testEnforce(de, "alice", "data1", "write", false);
@@ -40,6 +43,8 @@ public class SyncedDistributedAPIUnitTest {
         testEnforce(de, "data2_admin", "data2", "write", true);
         testEnforce(de, "alice", "data2", "read", true);
         testEnforce(de, "alice", "data2", "write", true);
+        testEnforce(de, "new_user", "data2", "write", true);
+        testEnforce(de, "new_user", "data2", "read", true);
 
         de.updatePolicySelf(() -> false, "p", "p", asList("alice", "data1", "read"), asList("alice", "data1", "write"));
         de.updatePolicySelf(() -> false, "g", "g", asList("alice", "data2_admin"), asList("tom", "alice"));


### PR DESCRIPTION
Hello, I am Alexandre, I currently work at [@ciandt](https://github.com/ciandt) as a Senior Software Engineer.

We are using jcasbin in my current project, we are having an issue updating multiple microservices instances.

Analyzing casbin I found Dispatcher and DistributedEnforcer that can handle our problem, but when I did some tests, I found these 2 issues:

1. DistributedEnforcer was ignoring a new rule that does not exist.
2. InternalEnforcer was not calling dispatcher on methods besides update policy method.

So this PR is to solve both problems and also I added unit test scenarios to cover these new lines of code.

Thank you.

edit: Fixed some codebeat issues reported 