### PR TITLE
feat: add synchronized version of methods into SyncedEnforcer

### DIFF
--- a/src/main/java/org/casbin/jcasbin/main/SyncedEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/SyncedEnforcer.java
@@ -1326,7 +1326,6 @@ public class SyncedEnforcer extends Enforcer {
     private <T> T runSynchronized(Supplier<T> action, Lock lock) {
         try {
             lock.lock();
-            READ_WRITE_LOCK.readLock().lock();
             return action.get();
         } finally {
             lock.unlock();

--- a/src/main/java/org/casbin/jcasbin/main/SyncedEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/SyncedEnforcer.java
@@ -19,6 +19,7 @@ import org.casbin.jcasbin.persist.Adapter;
 import org.casbin.jcasbin.persist.Watcher;
 
 import java.util.List;
+import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;
@@ -113,7 +114,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public void clearPolicy() {
-        runSynchronized(super::clearPolicy);
+        runSynchronized(super::clearPolicy, READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -121,7 +122,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public void loadPolicy() {
-        runSynchronized(super::loadPolicy);
+        runSynchronized(super::loadPolicy, READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -131,7 +132,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public void loadFilteredPolicy(Object filter) {
-        runSynchronized(() -> super.loadFilteredPolicy(filter));
+        runSynchronized(() -> super.loadFilteredPolicy(filter), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -140,7 +141,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public void savePolicy() {
-        runSynchronized(super::savePolicy);
+        runSynchronized(super::savePolicy, READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -149,7 +150,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public void buildRoleLinks() {
-        runSynchronized(super::buildRoleLinks);
+        runSynchronized(super::buildRoleLinks, READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -162,7 +163,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean enforce(Object... rvals) {
-        return runSynchronized(() -> super.enforce(rvals));
+        return runSynchronized(() -> super.enforce(rvals), READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -176,7 +177,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean enforceWithMatcher(String matcher, Object... rvals) {
-        return runSynchronized(() -> super.enforceWithMatcher(matcher, rvals));
+        return runSynchronized(() -> super.enforceWithMatcher(matcher, rvals), READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -187,7 +188,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<Boolean> batchEnforce(List<List<String>> rules) {
-        return runSynchronized(() -> super.batchEnforce(rules));
+        return runSynchronized(() -> super.batchEnforce(rules), READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -199,32 +200,32 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<Boolean> batchEnforceWithMatcher(String matcher, List<List<String>> rules) {
-        return runSynchronized(() -> super.batchEnforceWithMatcher(matcher, rules));
+        return runSynchronized(() -> super.batchEnforceWithMatcher(matcher, rules), READ_WRITE_LOCK.readLock());
     }
 
     /**
      * getAllSubjects gets the list of subjects that show up in the current policy.
      *
      * @return all the subjects in "p" policy rules. It actually collects the
-     *         0-index elements of "p" policy rules. So make sure your subject
-     *         is the 0-index element, like (sub, obj, act). Duplicates are removed.
+     * 0-index elements of "p" policy rules. So make sure your subject
+     * is the 0-index element, like (sub, obj, act). Duplicates are removed.
      */
     @Override
     public List<String> getAllSubjects() {
-        return runSynchronized(super::getAllSubjects);
+        return runSynchronized(super::getAllSubjects, READ_WRITE_LOCK.readLock());
     }
 
     /**
      * getAllObjects gets the list of objects that show up in the current policy.
      *
      * @return all the objects in "p" policy rules. It actually collects the
-     *         1-index elements of "p" policy rules. So make sure your object
-     *         is the 1-index element, like (sub, obj, act).
-     *         Duplicates are removed.
+     * 1-index elements of "p" policy rules. So make sure your object
+     * is the 1-index element, like (sub, obj, act).
+     * Duplicates are removed.
      */
     @Override
     public List<String> getAllObjects() {
-        return runSynchronized(super::getAllObjects);
+        return runSynchronized(super::getAllObjects, READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -232,26 +233,26 @@ public class SyncedEnforcer extends Enforcer {
      *
      * @param ptype the policy type, can be "p", "p2", "p3", ..
      * @return all the objects in policy rules of the ptype type. It actually
-     *         collects the 1-index elements of the policy rules. So make sure
-     *         your object is the 1-index element, like (sub, obj, act).
-     *         Duplicates are removed.
+     * collects the 1-index elements of the policy rules. So make sure
+     * your object is the 1-index element, like (sub, obj, act).
+     * Duplicates are removed.
      */
     @Override
     public List<String> getAllNamedObjects(String ptype) {
-        return runSynchronized(() -> super.getAllNamedObjects(ptype));
+        return runSynchronized(() -> super.getAllNamedObjects(ptype), READ_WRITE_LOCK.readLock());
     }
 
     /**
      * getAllActions gets the list of actions that show up in the current policy.
      *
      * @return all the actions in "p" policy rules. It actually collects
-     *         the 2-index elements of "p" policy rules. So make sure your action
-     *         is the 2-index element, like (sub, obj, act).
-     *         Duplicates are removed.
+     * the 2-index elements of "p" policy rules. So make sure your action
+     * is the 2-index element, like (sub, obj, act).
+     * Duplicates are removed.
      */
     @Override
     public List<String> getAllActions() {
-        return runSynchronized(super::getAllActions);
+        return runSynchronized(super::getAllActions, READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -259,26 +260,26 @@ public class SyncedEnforcer extends Enforcer {
      *
      * @param ptype the policy type, can be "p", "p2", "p3", ..
      * @return all the actions in policy rules of the ptype type. It actually
-     *         collects the 2-index elements of the policy rules. So make sure
-     *         your action is the 2-index element, like (sub, obj, act).
-     *         Duplicates are removed.
+     * collects the 2-index elements of the policy rules. So make sure
+     * your action is the 2-index element, like (sub, obj, act).
+     * Duplicates are removed.
      */
     @Override
     public List<String> getAllNamedActions(String ptype) {
-        return runSynchronized(() -> super.getAllNamedActions(ptype));
+        return runSynchronized(() -> super.getAllNamedActions(ptype), READ_WRITE_LOCK.readLock());
     }
 
     /**
      * getAllRoles gets the list of roles that show up in the current policy.
      *
      * @return all the roles in "g" policy rules. It actually collects
-     *         the 1-index elements of "g" policy rules. So make sure your
-     *         role is the 1-index element, like (sub, role).
-     *         Duplicates are removed.
+     * the 1-index elements of "g" policy rules. So make sure your
+     * role is the 1-index element, like (sub, role).
+     * Duplicates are removed.
      */
     @Override
     public List<String> getAllRoles() {
-        return runSynchronized(super::getAllRoles);
+        return runSynchronized(super::getAllRoles, READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -286,13 +287,13 @@ public class SyncedEnforcer extends Enforcer {
      *
      * @param ptype the policy type, can be "g", "g2", "g3", ..
      * @return all the subjects in policy rules of the ptype type. It actually
-     *         collects the 0-index elements of the policy rules. So make
-     *         sure your subject is the 0-index element, like (sub, obj, act).
-     *         Duplicates are removed.
+     * collects the 0-index elements of the policy rules. So make
+     * sure your subject is the 0-index element, like (sub, obj, act).
+     * Duplicates are removed.
      */
     @Override
     public List<String> getAllNamedRoles(String ptype) {
-        return runSynchronized(() -> super.getAllNamedRoles(ptype));
+        return runSynchronized(() -> super.getAllNamedRoles(ptype), READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -302,20 +303,20 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<List<String>> getPolicy() {
-        return runSynchronized(super::getPolicy);
+        return runSynchronized(super::getPolicy, READ_WRITE_LOCK.readLock());
     }
 
     /**
      * getFilteredPolicy gets all the authorization rules in the policy, field filters can be specified.
      *
-     * @param fieldIndex the policy rule's start index to be matched.
+     * @param fieldIndex  the policy rule's start index to be matched.
      * @param fieldValues the field values to be matched, value ""
      *                    means not to match this field.
      * @return the filtered "p" policy rules.
      */
     @Override
     public List<List<String>> getFilteredPolicy(int fieldIndex, String... fieldValues) {
-        return runSynchronized(() -> super.getFilteredPolicy(fieldIndex, fieldValues));
+        return runSynchronized(() -> super.getFilteredPolicy(fieldIndex, fieldValues), READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -326,21 +327,21 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<List<String>> getNamedPolicy(String ptype) {
-        return runSynchronized(() -> super.getNamedPolicy(ptype));
+        return runSynchronized(() -> super.getNamedPolicy(ptype), READ_WRITE_LOCK.readLock());
     }
 
     /**
      * getFilteredNamedPolicy gets all the authorization rules in the named policy, field filters can be specified.
      *
-     * @param ptype the policy type, can be "p", "p2", "p3", ..
-     * @param fieldIndex the policy rule's start index to be matched.
+     * @param ptype       the policy type, can be "p", "p2", "p3", ..
+     * @param fieldIndex  the policy rule's start index to be matched.
      * @param fieldValues the field values to be matched, value ""
      *                    means not to match this field.
      * @return the filtered "p" policy rules of the specified ptype.
      */
     @Override
     public List<List<String>> getFilteredNamedPolicy(String ptype, int fieldIndex, String... fieldValues) {
-        return runSynchronized(() -> super.getFilteredNamedPolicy(ptype, fieldIndex, fieldValues));
+        return runSynchronized(() -> super.getFilteredNamedPolicy(ptype, fieldIndex, fieldValues), READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -350,7 +351,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<List<String>> getGroupingPolicy() {
-        return runSynchronized(super::getGroupingPolicy);
+        return runSynchronized(super::getGroupingPolicy, READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -361,20 +362,20 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<String> getRolesForUser(String name) {
-        return runSynchronized(() -> super.getRolesForUser(name));
+        return runSynchronized(() -> super.getRolesForUser(name), READ_WRITE_LOCK.readLock());
     }
 
     /**
      * getFilteredGroupingPolicy gets all the role inheritance rules in the policy, field filters can be specified.
      *
-     * @param fieldIndex the policy rule's start index to be matched.
+     * @param fieldIndex  the policy rule's start index to be matched.
      * @param fieldValues the field values to be matched, value ""
-                          means not to match this field.
+     *                    means not to match this field.
      * @return the filtered "g" policy rules.
      */
     @Override
     public List<List<String>> getFilteredGroupingPolicy(int fieldIndex, String... fieldValues) {
-        return runSynchronized(() -> super.getFilteredGroupingPolicy(fieldIndex, fieldValues));
+        return runSynchronized(() -> super.getFilteredGroupingPolicy(fieldIndex, fieldValues), READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -385,21 +386,21 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<List<String>> getNamedGroupingPolicy(String ptype) {
-        return runSynchronized(() -> super.getNamedGroupingPolicy(ptype));
+        return runSynchronized(() -> super.getNamedGroupingPolicy(ptype), READ_WRITE_LOCK.readLock());
     }
 
     /**
      * getFilteredNamedGroupingPolicy gets all the role inheritance rules in the policy, field filters can be specified.
      *
-     * @param ptype the policy type, can be "g", "g2", "g3", ..
-     * @param fieldIndex the policy rule's start index to be matched.
+     * @param ptype       the policy type, can be "g", "g2", "g3", ..
+     * @param fieldIndex  the policy rule's start index to be matched.
      * @param fieldValues the field values to be matched, value ""
      *                    means not to match this field.
      * @return the filtered "g" policy rules of the specified ptype.
      */
     @Override
     public List<List<String>> getFilteredNamedGroupingPolicy(String ptype, int fieldIndex, String... fieldValues) {
-        return runSynchronized(() -> super.getFilteredNamedGroupingPolicy(ptype, fieldIndex, fieldValues));
+        return runSynchronized(() -> super.getFilteredNamedGroupingPolicy(ptype, fieldIndex, fieldValues), READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -410,7 +411,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean hasPolicy(List<String> params) {
-        return runSynchronized(() -> super.hasPolicy(params));
+        return runSynchronized(() -> super.hasPolicy(params), READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -421,31 +422,31 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean hasPolicy(String... params) {
-        return runSynchronized(() -> super.hasPolicy(params));
+        return runSynchronized(() -> super.hasPolicy(params), READ_WRITE_LOCK.readLock());
     }
 
     /**
      * hasNamedPolicy determines whether a named authorization rule exists.
      *
-     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @param ptype  the policy type, can be "p", "p2", "p3", ..
      * @param params the "p" policy rule.
      * @return whether the rule exists.
      */
     @Override
     public boolean hasNamedPolicy(String ptype, List<String> params) {
-        return runSynchronized(() -> super.hasNamedPolicy(ptype, params));
+        return runSynchronized(() -> super.hasNamedPolicy(ptype, params), READ_WRITE_LOCK.readLock());
     }
 
     /**
      * hasNamedPolicy determines whether a named authorization rule exists.
      *
-     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @param ptype  the policy type, can be "p", "p2", "p3", ..
      * @param params the "p" policy rule.
      * @return whether the rule exists.
      */
     @Override
     public boolean hasNamedPolicy(String ptype, String... params) {
-        return runSynchronized(() -> super.hasNamedPolicy(ptype, params));
+        return runSynchronized(() -> super.hasNamedPolicy(ptype, params), READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -458,7 +459,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addPolicy(List<String> params) {
-        return runSynchronized(() -> super.addPolicy(params));
+        return runSynchronized(() -> super.addPolicy(params), READ_WRITE_LOCK.writeLock());
     }
 
 
@@ -472,7 +473,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addPolicies(List<List<String>> rules) {
-        return runSynchronized(() -> super.addPolicies(rules));
+        return runSynchronized(() -> super.addPolicies(rules), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -484,7 +485,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean updatePolicy(List<String> params1, List<String> params2) {
-        return runSynchronized(() -> super.updatePolicy(params1, params2));
+        return runSynchronized(() -> super.updatePolicy(params1, params2), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -497,7 +498,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addPolicy(String... params) {
-        return runSynchronized(() -> super.addPolicy(params));
+        return runSynchronized(() -> super.addPolicy(params), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -510,7 +511,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addPolicies(String[][] rules) {
-        return runSynchronized(() -> super.addPolicies(rules));
+        return runSynchronized(() -> super.addPolicies(rules), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -518,13 +519,13 @@ public class SyncedEnforcer extends Enforcer {
      * If the rule already exists, the function returns false and the rule will not be added.
      * Otherwise the function returns true by adding the new rule.
      *
-     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @param ptype  the policy type, can be "p", "p2", "p3", ..
      * @param params the "p" policy rule.
      * @return succeeds or not.
      */
     @Override
     public boolean addNamedPolicy(String ptype, List<String> params) {
-        return runSynchronized(() -> super.addNamedPolicy(ptype, params));
+        return runSynchronized(() -> super.addNamedPolicy(ptype, params), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -538,7 +539,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addNamedPolicies(String ptype, List<List<String>> rules) {
-        return runSynchronized(() -> super.addNamedPolicies(ptype, rules));
+        return runSynchronized(() -> super.addNamedPolicies(ptype, rules), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -551,7 +552,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean updateNamedPolicy(String ptype, List<String> params1, List<String> params2) {
-        return runSynchronized(() -> super.updateNamedPolicy(ptype, params1, params2));
+        return runSynchronized(() -> super.updateNamedPolicy(ptype, params1, params2), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -563,7 +564,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean updateGroupingPolicy(List<String> params1, List<String> params2) {
-        return runSynchronized(() -> super.updateGroupingPolicy(params1, params2));
+        return runSynchronized(() -> super.updateGroupingPolicy(params1, params2), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -576,7 +577,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean updateNamedGroupingPolicy(String ptype, List<String> params1, List<String> params2) {
-        return runSynchronized(() -> super.updateNamedGroupingPolicy(ptype, params1, params2));
+        return runSynchronized(() -> super.updateNamedGroupingPolicy(ptype, params1, params2), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -584,13 +585,13 @@ public class SyncedEnforcer extends Enforcer {
      * If the rule already exists, the function returns false and the rule will not be added.
      * Otherwise the function returns true by adding the new rule.
      *
-     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @param ptype  the policy type, can be "p", "p2", "p3", ..
      * @param params the "p" policy rule.
      * @return succeeds or not.
      */
     @Override
     public boolean addNamedPolicy(String ptype, String... params) {
-        return runSynchronized(() -> super.addNamedPolicy(ptype, params));
+        return runSynchronized(() -> super.addNamedPolicy(ptype, params), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -601,7 +602,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean removePolicy(List<String> params) {
-        return runSynchronized(() -> super.removePolicy(params));
+        return runSynchronized(() -> super.removePolicy(params), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -612,7 +613,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean removePolicy(String... params) {
-        return runSynchronized(() -> super.removePolicy(params));
+        return runSynchronized(() -> super.removePolicy(params), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -623,7 +624,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean removePolicies(List<List<String>> rules) {
-        return runSynchronized(() -> super.removePolicies(rules));
+        return runSynchronized(() -> super.removePolicies(rules), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -634,44 +635,44 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean removePolicies(String[][] rules) {
-        return runSynchronized(() -> super.removePolicies(rules));
+        return runSynchronized(() -> super.removePolicies(rules), READ_WRITE_LOCK.writeLock());
     }
 
     /**
      * removeFilteredPolicy removes an authorization rule from the current policy, field filters can be specified.
      *
-     * @param fieldIndex the policy rule's start index to be matched.
+     * @param fieldIndex  the policy rule's start index to be matched.
      * @param fieldValues the field values to be matched, value ""
      *                    means not to match this field.
      * @return succeeds or not.
      */
     @Override
     public boolean removeFilteredPolicy(int fieldIndex, String... fieldValues) {
-        return runSynchronized(() -> super.removeFilteredPolicy(fieldIndex, fieldValues));
+        return runSynchronized(() -> super.removeFilteredPolicy(fieldIndex, fieldValues), READ_WRITE_LOCK.writeLock());
     }
 
     /**
      * removeNamedPolicy removes an authorization rule from the current named policy.
      *
-     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @param ptype  the policy type, can be "p", "p2", "p3", ..
      * @param params the "p" policy rule.
      * @return succeeds or not.
      */
     @Override
     public boolean removeNamedPolicy(String ptype, List<String> params) {
-        return runSynchronized(() -> super.removeNamedPolicy(ptype, params));
+        return runSynchronized(() -> super.removeNamedPolicy(ptype, params), READ_WRITE_LOCK.writeLock());
     }
 
     /**
      * removeNamedPolicy removes an authorization rule from the current named policy.
      *
-     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @param ptype  the policy type, can be "p", "p2", "p3", ..
      * @param params the "p" policy rule.
      * @return succeeds or not.
      */
     @Override
     public boolean removeNamedPolicy(String ptype, String... params) {
-        return runSynchronized(() -> super.removeNamedPolicy(ptype, params));
+        return runSynchronized(() -> super.removeNamedPolicy(ptype, params), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -683,21 +684,21 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean removeNamedPolicies(String ptype, List<List<String>> rules) {
-        return runSynchronized(() -> super.removeNamedPolicies(ptype, rules));
+        return runSynchronized(() -> super.removeNamedPolicies(ptype, rules), READ_WRITE_LOCK.writeLock());
     }
 
     /**
      * removeFilteredNamedPolicy removes an authorization rule from the current named policy, field filters can be specified.
      *
-     * @param ptype the policy type, can be "p", "p2", "p3", ..
-     * @param fieldIndex the policy rule's start index to be matched.
+     * @param ptype       the policy type, can be "p", "p2", "p3", ..
+     * @param fieldIndex  the policy rule's start index to be matched.
      * @param fieldValues the field values to be matched, value ""
      *                    means not to match this field.
      * @return succeeds or not.
      */
     @Override
     public boolean removeFilteredNamedPolicy(String ptype, int fieldIndex, String... fieldValues) {
-        return runSynchronized(() -> super.removeFilteredNamedPolicy(ptype, fieldIndex, fieldValues));
+        return runSynchronized(() -> super.removeFilteredNamedPolicy(ptype, fieldIndex, fieldValues), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -708,7 +709,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean hasGroupingPolicy(List<String> params) {
-        return runSynchronized(() -> super.hasGroupingPolicy(params));
+        return runSynchronized(() -> super.hasGroupingPolicy(params), READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -719,31 +720,31 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean hasGroupingPolicy(String... params) {
-        return runSynchronized(() -> super.hasGroupingPolicy(params));
+        return runSynchronized(() -> super.hasGroupingPolicy(params), READ_WRITE_LOCK.readLock());
     }
 
     /**
      * hasNamedGroupingPolicy determines whether a named role inheritance rule exists.
      *
-     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @param ptype  the policy type, can be "g", "g2", "g3", ..
      * @param params the "g" policy rule.
      * @return whether the rule exists.
      */
     @Override
     public boolean hasNamedGroupingPolicy(String ptype, List<String> params) {
-        return runSynchronized(() -> super.hasNamedGroupingPolicy(ptype, params));
+        return runSynchronized(() -> super.hasNamedGroupingPolicy(ptype, params), READ_WRITE_LOCK.readLock());
     }
 
     /**
      * hasNamedGroupingPolicy determines whether a named role inheritance rule exists.
      *
-     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @param ptype  the policy type, can be "g", "g2", "g3", ..
      * @param params the "g" policy rule.
      * @return whether the rule exists.
      */
     @Override
     public boolean hasNamedGroupingPolicy(String ptype, String... params) {
-        return runSynchronized(() -> super.hasNamedGroupingPolicy(ptype, params));
+        return runSynchronized(() -> super.hasNamedGroupingPolicy(ptype, params), READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -756,7 +757,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addGroupingPolicy(List<String> params) {
-        return runSynchronized(() -> super.addGroupingPolicy(params));
+        return runSynchronized(() -> super.addGroupingPolicy(params), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -769,7 +770,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addGroupingPolicy(String... params) {
-        return runSynchronized(() -> super.addGroupingPolicy(params));
+        return runSynchronized(() -> super.addGroupingPolicy(params), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -782,7 +783,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addGroupingPolicies(List<List<String>> rules) {
-        return runSynchronized(() -> super.addGroupingPolicies(rules));
+        return runSynchronized(() -> super.addGroupingPolicies(rules), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -795,7 +796,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addGroupingPolicies(String[][] rules) {
-        return runSynchronized(() -> super.addGroupingPolicies(rules));
+        return runSynchronized(() -> super.addGroupingPolicies(rules), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -803,13 +804,13 @@ public class SyncedEnforcer extends Enforcer {
      * If the rule already exists, the function returns false and the rule will not be added.
      * Otherwise the function returns true by adding the new rule.
      *
-     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @param ptype  the policy type, can be "g", "g2", "g3", ..
      * @param params the "g" policy rule.
      * @return succeeds or not.
      */
     @Override
     public boolean addNamedGroupingPolicy(String ptype, List<String> params) {
-        return runSynchronized(() -> super.addNamedGroupingPolicy(ptype, params));
+        return runSynchronized(() -> super.addNamedGroupingPolicy(ptype, params), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -817,13 +818,13 @@ public class SyncedEnforcer extends Enforcer {
      * If the rule already exists, the function returns false and the rule will not be added.
      * Otherwise the function returns true by adding the new rule.
      *
-     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @param ptype  the policy type, can be "g", "g2", "g3", ..
      * @param params the "g" policy rule.
      * @return succeeds or not.
      */
     @Override
     public boolean addNamedGroupingPolicy(String ptype, String... params) {
-        return runSynchronized(() -> super.addNamedGroupingPolicy(ptype, params));
+        return runSynchronized(() -> super.addNamedGroupingPolicy(ptype, params), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -837,7 +838,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addNamedGroupingPolicies(String ptype, List<List<String>> rules) {
-        return runSynchronized(() -> super.addNamedGroupingPolicies(ptype, rules));
+        return runSynchronized(() -> super.addNamedGroupingPolicies(ptype, rules), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -851,7 +852,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addNamedGroupingPolicies(String ptype, String[][] rules) {
-        return runSynchronized(() -> super.addNamedGroupingPolicies(ptype, rules));
+        return runSynchronized(() -> super.addNamedGroupingPolicies(ptype, rules), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -862,7 +863,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean removeGroupingPolicy(List<String> params) {
-        return runSynchronized(() -> super.removeGroupingPolicy(params));
+        return runSynchronized(() -> super.removeGroupingPolicy(params), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -873,7 +874,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean removeGroupingPolicy(String... params) {
-        return runSynchronized(() -> super.removeGroupingPolicy(params));
+        return runSynchronized(() -> super.removeGroupingPolicy(params), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -884,7 +885,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean removeGroupingPolicies(List<List<String>> rules) {
-        return runSynchronized(() -> super.removeGroupingPolicies(rules));
+        return runSynchronized(() -> super.removeGroupingPolicies(rules), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -895,44 +896,44 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean removeGroupingPolicies(String[][] rules) {
-        return runSynchronized(() -> super.removeGroupingPolicies(rules));
+        return runSynchronized(() -> super.removeGroupingPolicies(rules), READ_WRITE_LOCK.writeLock());
     }
 
     /**
      * removeFilteredGroupingPolicy removes a role inheritance rule from the current policy, field filters can be specified.
      *
-     * @param fieldIndex the policy rule's start index to be matched.
+     * @param fieldIndex  the policy rule's start index to be matched.
      * @param fieldValues the field values to be matched, value ""
      *                    means not to match this field.
      * @return succeeds or not.
      */
     @Override
     public boolean removeFilteredGroupingPolicy(int fieldIndex, String... fieldValues) {
-        return runSynchronized(() -> super.removeFilteredGroupingPolicy(fieldIndex, fieldValues));
+        return runSynchronized(() -> super.removeFilteredGroupingPolicy(fieldIndex, fieldValues), READ_WRITE_LOCK.writeLock());
     }
 
     /**
      * removeNamedGroupingPolicy removes a role inheritance rule from the current named policy.
      *
-     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @param ptype  the policy type, can be "g", "g2", "g3", ..
      * @param params the "g" policy rule.
      * @return succeeds or not.
      */
     @Override
     public boolean removeNamedGroupingPolicy(String ptype, List<String> params) {
-        return runSynchronized(() -> super.removeNamedGroupingPolicy(ptype, params));
+        return runSynchronized(() -> super.removeNamedGroupingPolicy(ptype, params), READ_WRITE_LOCK.writeLock());
     }
 
     /**
      * removeNamedGroupingPolicy removes a role inheritance rule from the current named policy.
      *
-     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @param ptype  the policy type, can be "g", "g2", "g3", ..
      * @param params the "g" policy rule.
      * @return succeeds or not.
      */
     @Override
     public boolean removeNamedGroupingPolicy(String ptype, String... params) {
-        return runSynchronized(() -> super.removeNamedGroupingPolicy(ptype, params));
+        return runSynchronized(() -> super.removeNamedGroupingPolicy(ptype, params), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -944,7 +945,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean removeNamedGroupingPolicies(String ptype, List<List<String>> rules) {
-        return runSynchronized(() -> super.removeNamedGroupingPolicies(ptype, rules));
+        return runSynchronized(() -> super.removeNamedGroupingPolicies(ptype, rules), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -956,21 +957,21 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean removeNamedGroupingPolicies(String ptype, String[][] rules) {
-        return runSynchronized(() -> super.removeNamedGroupingPolicies(ptype, rules));
+        return runSynchronized(() -> super.removeNamedGroupingPolicies(ptype, rules), READ_WRITE_LOCK.writeLock());
     }
 
     /**
      * removeFilteredNamedGroupingPolicy removes a role inheritance rule from the current named policy, field filters can be specified.
      *
-     * @param ptype the policy type, can be "g", "g2", "g3", ..
-     * @param fieldIndex the policy rule's start index to be matched.
+     * @param ptype       the policy type, can be "g", "g2", "g3", ..
+     * @param fieldIndex  the policy rule's start index to be matched.
      * @param fieldValues the field values to be matched, value ""
      *                    means not to match this field.
      * @return succeeds or not.
      */
     @Override
     public boolean removeFilteredNamedGroupingPolicy(String ptype, int fieldIndex, String... fieldValues) {
-        return runSynchronized(() -> super.removeFilteredNamedGroupingPolicy(ptype, fieldIndex, fieldValues));
+        return runSynchronized(() -> super.removeFilteredNamedGroupingPolicy(ptype, fieldIndex, fieldValues), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -981,7 +982,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<String> getUsersForRole(String name) {
-        return runSynchronized(() -> super.getUsersForRole(name));
+        return runSynchronized(() -> super.getUsersForRole(name), READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -993,7 +994,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean hasRoleForUser(String name, String role) {
-        return runSynchronized(() -> super.hasRoleForUser(name, role));
+        return runSynchronized(() -> super.hasRoleForUser(name, role), READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -1006,7 +1007,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addRoleForUser(String user, String role) {
-        return runSynchronized(() -> super.addRoleForUser(user, role));
+        return runSynchronized(() -> super.addRoleForUser(user, role), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -1019,7 +1020,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean deleteRoleForUser(String user, String role) {
-        return runSynchronized(() -> super.deleteRoleForUser(user, role));
+        return runSynchronized(() -> super.deleteRoleForUser(user, role), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -1031,7 +1032,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean deleteRolesForUser(String user) {
-        return runSynchronized(() -> super.deleteRolesForUser(user));
+        return runSynchronized(() -> super.deleteRolesForUser(user), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -1043,7 +1044,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean deleteUser(String user) {
-        return runSynchronized(() -> super.deleteUser(user));
+        return runSynchronized(() -> super.deleteUser(user), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -1053,7 +1054,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public void deleteRole(String role) {
-        runSynchronized(() -> super.deleteRole(role));
+        runSynchronized(() -> super.deleteRole(role), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -1065,7 +1066,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean deletePermission(String... permission) {
-        return runSynchronized(() -> super.deletePermission(permission));
+        return runSynchronized(() -> super.deletePermission(permission), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -1077,7 +1078,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean deletePermission(List<String> permission) {
-        return runSynchronized(() -> super.deletePermission(permission));
+        return runSynchronized(() -> super.deletePermission(permission), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -1090,7 +1091,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addPermissionForUser(String user, String... permission) {
-        return runSynchronized(() -> super.addPermissionForUser(user, permission));
+        return runSynchronized(() -> super.addPermissionForUser(user, permission), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -1103,7 +1104,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addPermissionForUser(String user, List<String> permission) {
-        return runSynchronized(() -> super.addPermissionForUser(user, permission));
+        return runSynchronized(() -> super.addPermissionForUser(user, permission), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -1116,7 +1117,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean deletePermissionForUser(String user, String... permission) {
-        return runSynchronized(() -> super.deletePermissionForUser(user, permission));
+        return runSynchronized(() -> super.deletePermissionForUser(user, permission), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -1129,7 +1130,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean deletePermissionForUser(String user, List<String> permission) {
-        return runSynchronized(() -> super.deletePermissionForUser(user, permission));
+        return runSynchronized(() -> super.deletePermissionForUser(user, permission), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -1141,7 +1142,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean deletePermissionsForUser(String user) {
-        return runSynchronized(() -> super.deletePermissionsForUser(user));
+        return runSynchronized(() -> super.deletePermissionsForUser(user), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -1153,7 +1154,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<List<String>> getPermissionsForUser(String user, String... domain) {
-        return runSynchronized(() -> super.getPermissionsForUser(user, domain));
+        return runSynchronized(() -> super.getPermissionsForUser(user, domain), READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -1166,7 +1167,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<List<String>> getNamedPermissionsForUser(String pType, String user, String... domain) {
-        return runSynchronized(() -> super.getNamedPermissionsForUser(pType, user, domain));
+        return runSynchronized(() -> super.getNamedPermissionsForUser(pType, user, domain), READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -1178,7 +1179,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean hasPermissionForUser(String user, String... permission) {
-        return runSynchronized(() -> super.hasPermissionForUser(user, permission));
+        return runSynchronized(() -> super.hasPermissionForUser(user, permission), READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -1190,7 +1191,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean hasPermissionForUser(String user, List<String> permission) {
-        return runSynchronized(() -> super.hasPermissionForUser(user, permission));
+        return runSynchronized(() -> super.hasPermissionForUser(user, permission), READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -1219,7 +1220,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<String> getRolesForUserInDomain(String name, String domain) {
-        return runSynchronized(() -> super.getRolesForUserInDomain(name, domain));
+        return runSynchronized(() -> super.getRolesForUserInDomain(name, domain), READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -1231,7 +1232,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<List<String>> getPermissionsForUserInDomain(String user, String domain) {
-        return runSynchronized(() -> super.getPermissionsForUserInDomain(user, domain));
+        return runSynchronized(() -> super.getPermissionsForUserInDomain(user, domain), READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -1245,7 +1246,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addRoleForUserInDomain(String user, String role, String domain) {
-        return runSynchronized(() -> super.addRoleForUserInDomain(user, role, domain));
+        return runSynchronized(() -> super.addRoleForUserInDomain(user, role, domain), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -1259,7 +1260,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean deleteRoleForUserInDomain(String user, String role, String domain) {
-        return runSynchronized(() -> super.deleteRoleForUserInDomain(user, role, domain));
+        return runSynchronized(() -> super.deleteRoleForUserInDomain(user, role, domain), READ_WRITE_LOCK.writeLock());
     }
 
     /**
@@ -1278,7 +1279,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<String> getImplicitRolesForUser(String name, String... domain) {
-        return runSynchronized(() -> super.getImplicitRolesForUser(name, domain));
+        return runSynchronized(() -> super.getImplicitRolesForUser(name, domain), READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -1298,7 +1299,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<List<String>> getImplicitPermissionsForUser(String user, String... domain) {
-        return runSynchronized(() -> super.getImplicitPermissionsForUser(user, domain));
+        return runSynchronized(() -> super.getImplicitPermissionsForUser(user, domain), READ_WRITE_LOCK.readLock());
     }
 
     /**
@@ -1312,31 +1313,32 @@ public class SyncedEnforcer extends Enforcer {
      * GetImplicitPermissionsForUser("alice") can only get: [["admin", "data1", "read"]], whose policy is default policy "p"
      * But you can specify the named policy "p2" to get: [["admin", "create"]] by GetNamedImplicitPermissionsForUser("p2","alice")
      *
-     * @param pType     the name policy.
-     * @param user      the user.
-     * @param domain    the user's domain.
+     * @param pType  the name policy.
+     * @param user   the user.
+     * @param domain the user's domain.
      * @return implicit permissions for a user or role by named policy.
      */
     @Override
     public List<List<String>> getNamedImplicitPermissionsForUser(String pType, String user, String... domain) {
-        return runSynchronized(() -> super.getNamedImplicitPermissionsForUser(pType, user, domain));
+        return runSynchronized(() -> super.getNamedImplicitPermissionsForUser(pType, user, domain), READ_WRITE_LOCK.readLock());
     }
 
-    private <T> T runSynchronized(Supplier<T> action) {
+    private <T> T runSynchronized(Supplier<T> action, Lock lock) {
         try {
+            lock.lock();
             READ_WRITE_LOCK.readLock().lock();
             return action.get();
         } finally {
-            READ_WRITE_LOCK.readLock().unlock();
+            lock.unlock();
         }
     }
 
-    private void runSynchronized(Runnable action) {
+    private void runSynchronized(Runnable action, Lock lock) {
         try {
-            READ_WRITE_LOCK.readLock().lock();
+            lock.lock();
             action.run();
         } finally {
-            READ_WRITE_LOCK.readLock().unlock();
+            lock.unlock();
         }
     }
 }

--- a/src/main/java/org/casbin/jcasbin/main/SyncedEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/SyncedEnforcer.java
@@ -21,6 +21,7 @@ import org.casbin.jcasbin.persist.Watcher;
 import java.util.List;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Supplier;
 
 /**
  * SyncedEnforcer = ManagementEnforcer + RBAC API.
@@ -112,12 +113,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public void clearPolicy() {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            super.clearPolicy();
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        runSynchronized(super::clearPolicy);
     }
 
     /**
@@ -125,12 +121,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public void loadPolicy() {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            super.loadPolicy();
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        runSynchronized(super::loadPolicy);
     }
 
     /**
@@ -140,12 +131,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public void loadFilteredPolicy(Object filter) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            super.loadFilteredPolicy(filter);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        runSynchronized(() -> super.loadFilteredPolicy(filter));
     }
 
     /**
@@ -154,12 +140,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public void savePolicy() {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            super.savePolicy();
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        runSynchronized(super::savePolicy);
     }
 
     /**
@@ -168,12 +149,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public void buildRoleLinks() {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            super.buildRoleLinks();
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        runSynchronized(super::buildRoleLinks);
     }
 
     /**
@@ -186,12 +162,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean enforce(Object... rvals) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.enforce(rvals);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.enforce(rvals));
     }
 
     /**
@@ -205,12 +176,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean enforceWithMatcher(String matcher, Object... rvals) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.enforceWithMatcher(matcher, rvals);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.enforceWithMatcher(matcher, rvals));
     }
 
     /**
@@ -221,12 +187,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<Boolean> batchEnforce(List<List<String>> rules) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.batchEnforce(rules);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.batchEnforce(rules));
     }
 
     /**
@@ -238,12 +199,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<Boolean> batchEnforceWithMatcher(String matcher, List<List<String>> rules) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.batchEnforceWithMatcher(matcher, rules);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.batchEnforceWithMatcher(matcher, rules));
     }
 
     /**
@@ -255,12 +211,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<String> getAllSubjects() {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.getAllSubjects();
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(this::getAllSubjects);
     }
 
     /**
@@ -273,12 +224,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<String> getAllObjects() {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.getAllObjects();
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(this::getAllObjects);
     }
 
     /**
@@ -292,12 +238,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<String> getAllNamedObjects(String ptype) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.getAllNamedObjects(ptype);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.getAllNamedObjects(ptype));
     }
 
     /**
@@ -310,12 +251,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<String> getAllActions() {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.getAllActions();
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(this::getAllActions);
     }
 
     /**
@@ -329,12 +265,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<String> getAllNamedActions(String ptype) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.getAllNamedActions(ptype);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.getAllNamedActions(ptype));
     }
 
     /**
@@ -347,12 +278,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<String> getAllRoles() {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.getAllRoles();
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(this::getAllRoles);
     }
 
     /**
@@ -366,12 +292,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<String> getAllNamedRoles(String ptype) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.getAllNamedRoles(ptype);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.getAllNamedRoles(ptype));
     }
 
     /**
@@ -381,12 +302,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<List<String>> getPolicy() {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.getPolicy();
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(this::getPolicy);
     }
 
     /**
@@ -399,12 +315,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<List<String>> getFilteredPolicy(int fieldIndex, String... fieldValues) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.getFilteredPolicy(fieldIndex, fieldValues);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.getFilteredPolicy(fieldIndex, fieldValues));
     }
 
     /**
@@ -415,12 +326,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<List<String>> getNamedPolicy(String ptype) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.getNamedPolicy(ptype);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.getNamedPolicy(ptype));
     }
 
     /**
@@ -434,12 +340,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<List<String>> getFilteredNamedPolicy(String ptype, int fieldIndex, String... fieldValues) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.getFilteredNamedPolicy(ptype, fieldIndex, fieldValues);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.getFilteredNamedPolicy(ptype, fieldIndex, fieldValues));
     }
 
     /**
@@ -449,12 +350,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<List<String>> getGroupingPolicy() {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.getGroupingPolicy();
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(this::getGroupingPolicy);
     }
 
     /**
@@ -465,12 +361,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<String> getRolesForUser(String name) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.getRolesForUser(name);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.getRolesForUser(name));
     }
 
     /**
@@ -483,12 +374,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<List<String>> getFilteredGroupingPolicy(int fieldIndex, String... fieldValues) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.getFilteredGroupingPolicy(fieldIndex, fieldValues);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.getFilteredGroupingPolicy(fieldIndex, fieldValues));
     }
 
     /**
@@ -499,12 +385,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<List<String>> getNamedGroupingPolicy(String ptype) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.getNamedGroupingPolicy(ptype);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.getNamedGroupingPolicy(ptype));
     }
 
     /**
@@ -518,12 +399,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<List<String>> getFilteredNamedGroupingPolicy(String ptype, int fieldIndex, String... fieldValues) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.getFilteredNamedGroupingPolicy(ptype, fieldIndex, fieldValues);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.getFilteredNamedGroupingPolicy(ptype, fieldIndex, fieldValues));
     }
 
     /**
@@ -534,12 +410,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean hasPolicy(List<String> params) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.hasPolicy(params);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.hasPolicy(params));
     }
 
     /**
@@ -550,12 +421,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean hasPolicy(String... params) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.hasPolicy(params);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.hasPolicy(params));
     }
 
     /**
@@ -567,13 +433,9 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean hasNamedPolicy(String ptype, List<String> params) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.hasNamedPolicy(ptype, params);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.hasNamedPolicy(ptype, params));
     }
+
     /**
      * hasNamedPolicy determines whether a named authorization rule exists.
      *
@@ -583,12 +445,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean hasNamedPolicy(String ptype, String... params) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.hasNamedPolicy(ptype, params);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.hasNamedPolicy(ptype, params));
     }
 
     /**
@@ -601,13 +458,33 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addPolicy(List<String> params) {
+        return runSynchronized(() -> super.addPolicy(params));
+    }
 
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.addPolicy(params);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+
+    /**
+     * addPolicies adds authorization rules to the current policy.
+     * If the rule already exists, the function returns false for the corresponding rule and the rule will not be added.
+     * Otherwise the function returns true for the corresponding rule by adding the new rule.
+     *
+     * @param rules the "p" policy rules, ptype "p" is implicitly used.
+     * @return succeeds or not.
+     */
+    @Override
+    public boolean addPolicies(List<List<String>> rules) {
+        return runSynchronized(() -> super.addPolicies(rules));
+    }
+
+    /**
+     * updatePolicy update an authorization rule to the current policy.
+     *
+     * @param params1 the old rule.
+     * @param params2 the new rule.
+     * @return succeeds or not.
+     */
+    @Override
+    public boolean updatePolicy(List<String> params1, List<String> params2) {
+        return runSynchronized(() -> super.updatePolicy(params1, params2));
     }
 
     /**
@@ -620,12 +497,20 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addPolicy(String... params) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.addPolicy(params);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.addPolicy(params));
+    }
+
+    /**
+     * addPolicies adds authorization rules to the current policy.
+     * If the rule already exists, the function returns false for the corresponding rule and the rule will not be added.
+     * Otherwise the function returns true for the corresponding rule by adding the new rule.
+     *
+     * @param rules the "p" policy rules, ptype "p" is implicitly used.
+     * @return succeeds or not.
+     */
+    @Override
+    public boolean addPolicies(String[][] rules) {
+        return runSynchronized(() -> super.addPolicies(rules));
     }
 
     /**
@@ -639,12 +524,59 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addNamedPolicy(String ptype, List<String> params) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.addNamedPolicy(ptype, params);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.addNamedPolicy(ptype, params));
+    }
+
+    /**
+     * addNamedPolicies adds authorization rules to the current named policy.
+     * If the rule already exists, the function returns false for the corresponding rule and the rule will not be added.
+     * Otherwise the function returns true for the corresponding by adding the new rule.
+     *
+     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @param rules the "p" policy rules.
+     * @return succeeds or not.
+     */
+    @Override
+    public boolean addNamedPolicies(String ptype, List<List<String>> rules) {
+        return runSynchronized(() -> super.addNamedPolicies(ptype, rules));
+    }
+
+    /**
+     * updateNamedPolicy updates an authorization rule to the current named policy.
+     *
+     * @param ptype   the policy type, can be "p", "p2", "p3", ..
+     * @param params1 the old rule.
+     * @param params2 the new rule.
+     * @return succeeds or not.
+     */
+    @Override
+    public boolean updateNamedPolicy(String ptype, List<String> params1, List<String> params2) {
+        return runSynchronized(() -> super.updateNamedPolicy(ptype, params1, params2));
+    }
+
+    /**
+     * UpdateGroupingPolicy updates an authorization rule to the current named policy.
+     *
+     * @param params1 the old rule.
+     * @param params2 the new rule.
+     * @return succeeds or not.
+     */
+    @Override
+    public boolean updateGroupingPolicy(List<String> params1, List<String> params2) {
+        return runSynchronized(() -> super.updateGroupingPolicy(params1, params2));
+    }
+
+    /**
+     * updateNamedGroupingPolicy updates an authorization rule to the current named policy.
+     *
+     * @param ptype   the policy type, can be "g", "g2", "g3", ..
+     * @param params1 the old rule.
+     * @param params2 the new rule.
+     * @return succeeds or not.
+     */
+    @Override
+    public boolean updateNamedGroupingPolicy(String ptype, List<String> params1, List<String> params2) {
+        return runSynchronized(() -> super.updateNamedGroupingPolicy(ptype, params1, params2));
     }
 
     /**
@@ -658,12 +590,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addNamedPolicy(String ptype, String... params) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.addNamedPolicy(ptype, params);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.addNamedPolicy(ptype, params));
     }
 
     /**
@@ -674,12 +601,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean removePolicy(List<String> params) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.removePolicy(params);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.removePolicy(params));
     }
 
     /**
@@ -690,12 +612,29 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean removePolicy(String... params) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.removePolicy(params);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.removePolicy(params));
+    }
+
+    /**
+     * removePolicies removes authorization rules from the current policy.
+     *
+     * @param rules the "p" policy rules, ptype "p" is implicitly used.
+     * @return succeeds or not.
+     */
+    @Override
+    public boolean removePolicies(List<List<String>> rules) {
+        return runSynchronized(() -> super.removePolicies(rules));
+    }
+
+    /**
+     * removePolicies removes authorization rules from the current policy.
+     *
+     * @param rules the "p" policy rules, ptype "p" is implicitly used.
+     * @return succeeds or not.
+     */
+    @Override
+    public boolean removePolicies(String[][] rules) {
+        return runSynchronized(() -> super.removePolicies(rules));
     }
 
     /**
@@ -708,12 +647,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean removeFilteredPolicy(int fieldIndex, String... fieldValues) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.removeFilteredPolicy(fieldIndex, fieldValues);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.removeFilteredPolicy(fieldIndex, fieldValues));
     }
 
     /**
@@ -725,12 +659,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean removeNamedPolicy(String ptype, List<String> params) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.removeNamedPolicy(ptype, params);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.removeNamedPolicy(ptype, params));
     }
 
     /**
@@ -742,12 +671,19 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean removeNamedPolicy(String ptype, String... params) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.removeNamedPolicy(ptype, params);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.removeNamedPolicy(ptype, params));
+    }
+
+    /**
+     * removeNamedPolicies removes authorization rules from the current named policy.
+     *
+     * @param ptype ptype the policy type, can be "p", "p2", "p3", ..
+     * @param rules the "p" policy rules.
+     * @return succeeds or not.
+     */
+    @Override
+    public boolean removeNamedPolicies(String ptype, List<List<String>> rules) {
+        return runSynchronized(() -> super.removeNamedPolicies(ptype, rules));
     }
 
     /**
@@ -761,12 +697,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean removeFilteredNamedPolicy(String ptype, int fieldIndex, String... fieldValues) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.removeFilteredNamedPolicy(ptype, fieldIndex, fieldValues);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.removeFilteredNamedPolicy(ptype, fieldIndex, fieldValues));
     }
 
     /**
@@ -777,12 +708,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean hasGroupingPolicy(List<String> params) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.hasGroupingPolicy(params);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.hasGroupingPolicy(params));
     }
 
     /**
@@ -793,12 +719,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean hasGroupingPolicy(String... params) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.hasGroupingPolicy(params);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.hasGroupingPolicy(params));
     }
 
     /**
@@ -810,12 +731,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean hasNamedGroupingPolicy(String ptype, List<String> params) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.hasNamedGroupingPolicy(ptype, params);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.hasNamedGroupingPolicy(ptype, params));
     }
 
     /**
@@ -827,12 +743,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean hasNamedGroupingPolicy(String ptype, String... params) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.hasNamedGroupingPolicy(ptype, params);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.hasNamedGroupingPolicy(ptype, params));
     }
 
     /**
@@ -845,12 +756,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addGroupingPolicy(List<String> params) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.addGroupingPolicy(params);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.addGroupingPolicy(params));
     }
 
     /**
@@ -863,12 +769,33 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addGroupingPolicy(String... params) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.addGroupingPolicy(params);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.addGroupingPolicy(params));
+    }
+
+    /**
+     * addGroupingPolicies adds role inheritance rules to the current policy.
+     * If the rule already exists, the function returns false for the corresponding policy rule and the rule will not be added.
+     * Otherwise the function returns true for the corresponding policy rule by adding the new rule.
+     *
+     * @param rules the "g" policy rules, ptype "g" is implicitly used.
+     * @return succeeds or not.
+     */
+    @Override
+    public boolean addGroupingPolicies(List<List<String>> rules) {
+        return runSynchronized(() -> super.addGroupingPolicies(rules));
+    }
+
+    /**
+     * addGroupingPolicies adds role inheritance rules to the current policy.
+     * If the rule already exists, the function returns false for the corresponding policy rule and the rule will not be added.
+     * Otherwise the function returns true for the corresponding policy rule by adding the new rule.
+     *
+     * @param rules the "g" policy rules, ptype "g" is implicitly used.
+     * @return succeeds or not.
+     */
+    @Override
+    public boolean addGroupingPolicies(String[][] rules) {
+        return runSynchronized(() -> super.addGroupingPolicies(rules));
     }
 
     /**
@@ -882,12 +809,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addNamedGroupingPolicy(String ptype, List<String> params) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.addNamedGroupingPolicy(ptype, params);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.addNamedGroupingPolicy(ptype, params));
     }
 
     /**
@@ -901,12 +823,35 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addNamedGroupingPolicy(String ptype, String... params) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.addNamedGroupingPolicy(ptype, params);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.addNamedGroupingPolicy(ptype, params));
+    }
+
+    /**
+     * addNamedGroupingPolicies adds named role inheritance rules to the current policy.
+     * If the rule already exists, the function returns false for the corresponding policy rule and the rule will not be added.
+     * Otherwise the function returns true for the corresponding policy rule by adding the new rule.
+     *
+     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @param rules the "g" policy rules.
+     * @return succeeds or not.
+     */
+    @Override
+    public boolean addNamedGroupingPolicies(String ptype, List<List<String>> rules) {
+        return runSynchronized(() -> super.addNamedGroupingPolicies(ptype, rules));
+    }
+
+    /**
+     * addNamedGroupingPolicies adds named role inheritance rules to the current policy.
+     * If the rule already exists, the function returns false for the corresponding policy rule and the rule will not be added.
+     * Otherwise the function returns true for the corresponding policy rule by adding the new rule.
+     *
+     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @param rules the "g" policy rules.
+     * @return succeeds or not.
+     */
+    @Override
+    public boolean addNamedGroupingPolicies(String ptype, String[][] rules) {
+        return runSynchronized(() -> super.addNamedGroupingPolicies(ptype, rules));
     }
 
     /**
@@ -917,12 +862,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean removeGroupingPolicy(List<String> params) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.removeGroupingPolicy(params);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.removeGroupingPolicy(params));
     }
 
     /**
@@ -933,12 +873,29 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean removeGroupingPolicy(String... params) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.removeGroupingPolicy(params);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.removeGroupingPolicy(params));
+    }
+
+    /**
+     * removeGroupingPolicies removes role inheritance rules from the current policy.
+     *
+     * @param rules the "g" policy rules, ptype "g" is implicitly used.
+     * @return succeeds or not.
+     */
+    @Override
+    public boolean removeGroupingPolicies(List<List<String>> rules) {
+        return runSynchronized(() -> super.removeGroupingPolicies(rules));
+    }
+
+    /**
+     * removeGroupingPolicies removes role inheritance rules from the current policy.
+     *
+     * @param rules the "g" policy rules, ptype "g" is implicitly used.
+     * @return succeeds or not.
+     */
+    @Override
+    public boolean removeGroupingPolicies(String[][] rules) {
+        return runSynchronized(() -> super.removeGroupingPolicies(rules));
     }
 
     /**
@@ -951,12 +908,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean removeFilteredGroupingPolicy(int fieldIndex, String... fieldValues) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.removeFilteredGroupingPolicy(fieldIndex, fieldValues);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.removeFilteredGroupingPolicy(fieldIndex, fieldValues));
     }
 
     /**
@@ -968,12 +920,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean removeNamedGroupingPolicy(String ptype, List<String> params) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.removeNamedGroupingPolicy(ptype, params);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.removeNamedGroupingPolicy(ptype, params));
     }
 
     /**
@@ -985,12 +932,31 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean removeNamedGroupingPolicy(String ptype, String... params) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.removeNamedGroupingPolicy(ptype, params);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.removeNamedGroupingPolicy(ptype, params));
+    }
+
+    /**
+     * removeNamedGroupingPolicies removes role inheritance rules from the current named policy.
+     *
+     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @param rules the "g" policy rules.
+     * @return succeeds or not.
+     */
+    @Override
+    public boolean removeNamedGroupingPolicies(String ptype, List<List<String>> rules) {
+        return runSynchronized(() -> super.removeNamedGroupingPolicies(ptype, rules));
+    }
+
+    /**
+     * removeNamedGroupingPolicies removes role inheritance rules from the current named policy.
+     *
+     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @param rules the "g" policy rules.
+     * @return succeeds or not.
+     */
+    @Override
+    public boolean removeNamedGroupingPolicies(String ptype, String[][] rules) {
+        return runSynchronized(() -> super.removeNamedGroupingPolicies(ptype, rules));
     }
 
     /**
@@ -1004,12 +970,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean removeFilteredNamedGroupingPolicy(String ptype, int fieldIndex, String... fieldValues) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.removeFilteredNamedGroupingPolicy(ptype, fieldIndex, fieldValues);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.removeFilteredNamedGroupingPolicy(ptype, fieldIndex, fieldValues));
     }
 
     /**
@@ -1020,12 +981,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<String> getUsersForRole(String name) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.getUsersForRole(name);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.getUsersForRole(name));
     }
 
     /**
@@ -1037,12 +993,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean hasRoleForUser(String name, String role) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.hasRoleForUser(name, role);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.hasRoleForUser(name, role));
     }
 
     /**
@@ -1055,12 +1006,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addRoleForUser(String user, String role) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.addRoleForUser(user, role);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.addRoleForUser(user, role));
     }
 
     /**
@@ -1073,12 +1019,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean deleteRoleForUser(String user, String role) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.deleteRoleForUser(user, role);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.deleteRoleForUser(user, role));
     }
 
     /**
@@ -1090,12 +1031,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean deleteRolesForUser(String user) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.deleteRolesForUser(user);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.deleteRolesForUser(user));
     }
 
     /**
@@ -1107,12 +1043,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean deleteUser(String user) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.deleteUser(user);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.deleteUser(user));
     }
 
     /**
@@ -1122,12 +1053,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public void deleteRole(String role) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            super.deleteRole(role);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        runSynchronized(() -> super.deleteRole(role));
     }
 
     /**
@@ -1139,12 +1065,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean deletePermission(String... permission) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.deletePermission(permission);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.deletePermission(permission));
     }
 
     /**
@@ -1156,12 +1077,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean deletePermission(List<String> permission) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.deletePermission(permission);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.deletePermission(permission));
     }
 
     /**
@@ -1174,12 +1090,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addPermissionForUser(String user, String... permission) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.addPermissionForUser(user, permission);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.addPermissionForUser(user, permission));
     }
 
     /**
@@ -1192,12 +1103,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addPermissionForUser(String user, List<String> permission) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.addPermissionForUser(user, permission);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.addPermissionForUser(user, permission));
     }
 
     /**
@@ -1210,12 +1116,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean deletePermissionForUser(String user, String... permission) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.deletePermissionForUser(user, permission);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.deletePermissionForUser(user, permission));
     }
 
     /**
@@ -1228,12 +1129,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean deletePermissionForUser(String user, List<String> permission) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.deletePermissionForUser(user, permission);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.deletePermissionForUser(user, permission));
     }
 
     /**
@@ -1245,12 +1141,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean deletePermissionsForUser(String user) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.deletePermissionsForUser(user);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.deletePermissionsForUser(user));
     }
 
     /**
@@ -1262,29 +1153,20 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<List<String>> getPermissionsForUser(String user, String... domain) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.getPermissionsForUser(user, domain);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.getPermissionsForUser(user, domain));
     }
 
     /**
      * GetNamedPermissionsForUser gets permissions for a user or role by named policy.
-     * @param pType     the name policy.
-     * @param user      the user.
-     * @param domain    domain.
+     *
+     * @param pType  the name policy.
+     * @param user   the user.
+     * @param domain domain.
      * @return the permissions.
      */
     @Override
     public List<List<String>> getNamedPermissionsForUser(String pType, String user, String... domain) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.getNamedPermissionsForUser(pType, user, domain);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.getNamedPermissionsForUser(pType, user, domain));
     }
 
     /**
@@ -1296,12 +1178,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean hasPermissionForUser(String user, String... permission) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.hasPermissionForUser(user, permission);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.hasPermissionForUser(user, permission));
     }
 
     /**
@@ -1313,12 +1190,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean hasPermissionForUser(String user, List<String> permission) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.hasPermissionForUser(user, permission);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.hasPermissionForUser(user, permission));
     }
 
     /**
@@ -1347,12 +1219,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<String> getRolesForUserInDomain(String name, String domain) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.getRolesForUserInDomain(name, domain);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.getRolesForUserInDomain(name, domain));
     }
 
     /**
@@ -1364,12 +1231,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<List<String>> getPermissionsForUserInDomain(String user, String domain) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.getPermissionsForUserInDomain(user, domain);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.getPermissionsForUserInDomain(user, domain));
     }
 
     /**
@@ -1383,12 +1245,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean addRoleForUserInDomain(String user, String role, String domain) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.addRoleForUserInDomain(user, role, domain);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.addRoleForUserInDomain(user, role, domain));
     }
 
     /**
@@ -1402,12 +1259,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public boolean deleteRoleForUserInDomain(String user, String role, String domain) {
-        try {
-            READ_WRITE_LOCK.writeLock().lock();
-            return super.deleteRoleForUserInDomain(user, role, domain);
-        } finally {
-            READ_WRITE_LOCK.writeLock().unlock();
-        }
+        return runSynchronized(() -> super.deleteRoleForUserInDomain(user, role, domain));
     }
 
     /**
@@ -1426,12 +1278,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<String> getImplicitRolesForUser(String name, String... domain) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.getImplicitRolesForUser(name, domain);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.getImplicitRolesForUser(name, domain));
     }
 
     /**
@@ -1451,12 +1298,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<List<String>> getImplicitPermissionsForUser(String user, String... domain) {
-        try {
-            READ_WRITE_LOCK.readLock().lock();
-            return super.getImplicitPermissionsForUser(user, domain);
-        } finally {
-            READ_WRITE_LOCK.readLock().unlock();
-        }
+        return runSynchronized(() -> super.getImplicitPermissionsForUser(user, domain));
     }
 
     /**
@@ -1477,9 +1319,22 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<List<String>> getNamedImplicitPermissionsForUser(String pType, String user, String... domain) {
+        return runSynchronized(() -> super.getNamedImplicitPermissionsForUser(pType, user, domain));
+    }
+
+    private <T> T runSynchronized(Supplier<T> action) {
         try {
             READ_WRITE_LOCK.readLock().lock();
-            return super.getNamedImplicitPermissionsForUser(pType, user, domain);
+            return action.get();
+        } finally {
+            READ_WRITE_LOCK.readLock().unlock();
+        }
+    }
+
+    private void runSynchronized(Runnable action) {
+        try {
+            READ_WRITE_LOCK.readLock().lock();
+            action.run();
         } finally {
             READ_WRITE_LOCK.readLock().unlock();
         }

--- a/src/main/java/org/casbin/jcasbin/main/SyncedEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/SyncedEnforcer.java
@@ -211,7 +211,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<String> getAllSubjects() {
-        return runSynchronized(this::getAllSubjects);
+        return runSynchronized(super::getAllSubjects);
     }
 
     /**
@@ -224,7 +224,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<String> getAllObjects() {
-        return runSynchronized(this::getAllObjects);
+        return runSynchronized(super::getAllObjects);
     }
 
     /**
@@ -251,7 +251,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<String> getAllActions() {
-        return runSynchronized(this::getAllActions);
+        return runSynchronized(super::getAllActions);
     }
 
     /**
@@ -278,7 +278,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<String> getAllRoles() {
-        return runSynchronized(this::getAllRoles);
+        return runSynchronized(super::getAllRoles);
     }
 
     /**
@@ -302,7 +302,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<List<String>> getPolicy() {
-        return runSynchronized(this::getPolicy);
+        return runSynchronized(super::getPolicy);
     }
 
     /**
@@ -350,7 +350,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<List<String>> getGroupingPolicy() {
-        return runSynchronized(this::getGroupingPolicy);
+        return runSynchronized(super::getGroupingPolicy);
     }
 
     /**


### PR DESCRIPTION
Fix: https://github.com/casbin/jcasbin/issues/290

Functions added into `SyncedEnforcer`:

- addPolicies(List<List<String>> rules)
- updatePolicy(List<String> params1, List<String> params2)
- addPolicies(String[][] rules)
- addNamedPolicies(String ptype, List<List<String>> rules)
- updateNamedPolicy(String ptype, List<String> params1, List<String> params2)
- updateGroupingPolicy(List<String> params1, List<String> params2)
- updateNamedGroupingPolicy(String ptype, List<String> params1, List<String> params2)
- removePolicies(List<List<String>> rules)
- removePolicies(String[][] rules)
- removeNamedPolicies(String ptype, List<List<String>> rules)
- addGroupingPolicies(List<List<String>> rules)
- addGroupingPolicies(String[][] rules)
- addNamedGroupingPolicies(String ptype, List<List<String>> rules)
- addNamedGroupingPolicies(String ptype, String[][] rules)
- removeGroupingPolicies(List<List<String>> rules)
- removeGroupingPolicies(String[][] rules)
- removeNamedGroupingPolicies(String ptype, List<List<String>> rules)
- removeNamedGroupingPolicies(String ptype, String[][] rules)

Also added private methods to reduce number of thread-lock related duplication code.