### PR TITLE
fix: `getRole()` in `SyncedEnforcer` thread unsafe

### DIFF
--- a/src/main/java/org/casbin/jcasbin/main/SyncedEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/SyncedEnforcer.java
@@ -391,7 +391,7 @@ public class SyncedEnforcer extends Enforcer {
      */
     @Override
     public List<String> getRolesForUser(String name) {
-        return runSynchronized(() -> super.getRolesForUser(name), READ_WRITE_LOCK.readLock());
+        return runSynchronized(() -> super.getRolesForUser(name), READ_WRITE_LOCK.writeLock());
     }
 
     /**


### PR DESCRIPTION
Fix: #309

`getRole()` in `SyncedEnforcer` do some write operate, so replace `read lock` to `write lock`.