### PR TITLE
feat: change aviator dependency to org.casbin.aviator.5.1.4-fix to support below Android 8.0 (API level 26)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,9 +186,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.googlecode.aviator</groupId>
+            <groupId>org.casbin</groupId>
             <artifactId>aviator</artifactId>
-            <version>5.3.0</version>
+            <version>5.1.4-fix</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
add support for Android SDK version < 26

Fix: https://github.com/casbin/jcasbin/issues/264