### PR TITLE
fix: fix ABAC rule with attribute that does not exist

### DIFF
--- a/examples/abac_rule_policy.csv
+++ b/examples/abac_rule_policy.csv
@@ -1,2 +1,3 @@
+p, r.sub.not_exist_attribute_test == true, /data0, read
 p, r.sub.age > 18 && r.sub.age < 25, /data1, read
 p, r.sub.age < 60, /data2, write

--- a/src/main/java/org/casbin/jcasbin/util/BuiltInFunctions.java
+++ b/src/main/java/org/casbin/jcasbin/util/BuiltInFunctions.java
@@ -402,7 +402,11 @@ public class BuiltInFunctions {
     public static boolean eval(String eval, Map<String, Object> env, AviatorEvaluatorInstance aviatorEval) {
         boolean res;
         if (aviatorEval != null) {
-            res = (boolean) aviatorEval.execute(eval, env);
+            try {
+                res = (boolean) aviatorEval.execute(eval, env);
+            } catch (Exception e) {
+                res = false;
+            }
         } else {
             res = (boolean) AviatorEvaluator.execute(eval, env);
         }

--- a/src/test/java/org/casbin/jcasbin/main/AbacAPIUnitTest.java
+++ b/src/test/java/org/casbin/jcasbin/main/AbacAPIUnitTest.java
@@ -25,6 +25,8 @@ public class AbacAPIUnitTest {
     public void testEval() {
         Enforcer e = new Enforcer("examples/abac_rule_model.conf", "examples/abac_rule_policy.csv");
         TestEvalRule alice = new TestEvalRule("alice", 18);
+        // rule with attribute not exist in object will return false, then check the following policy of ACL
+        testEnforce(e, alice, "/data0", "read", false);
         testEnforce(e, alice, "/data1", "read", false);
         testEnforce(e, alice, "/data1", "write", false);
         alice.setAge(19);


### PR DESCRIPTION
Fix: #332 

Rule with attribute not exist in object will throw exception, but no catch cause the error of #332. When exception is throw, eval should return false, then check the next one policy of ACL.
