### PR TITLE
fix: fix no enforceExplain in eft.Deny

### DIFF
--- a/src/main/java/org/casbin/jcasbin/effect/DefaultStreamEffector.java
+++ b/src/main/java/org/casbin/jcasbin/effect/DefaultStreamEffector.java
@@ -18,6 +18,7 @@ public class DefaultStreamEffector implements StreamEffector {
     private final String expr;
     private boolean done = false;
     private boolean effect = false;
+    private int explainIndex = -1;
 
     public DefaultStreamEffector(String expr) {
         this.expr = expr;
@@ -25,7 +26,7 @@ public class DefaultStreamEffector implements StreamEffector {
 
     @Override
     public StreamEffectorResult current() {
-        return new DefaultStreamEffectorResult(effect, done);
+        return new DefaultStreamEffectorResult(effect, done, explainIndex);
     }
 
     @Override
@@ -34,6 +35,7 @@ public class DefaultStreamEffector implements StreamEffector {
             case "some(where (p_eft == allow))":
                 if (eft == Effect.Allow) {
                     this.effect = true;
+                    explainIndex = currentIndex;
                     this.done = true;
                 }
                 break;
@@ -41,14 +43,17 @@ public class DefaultStreamEffector implements StreamEffector {
                 this.effect = true;
                 if (eft == Effect.Deny) {
                     this.effect = false;
+                    explainIndex = currentIndex;
                     this.done = true;
                 }
                 break;
             case "some(where (p_eft == allow)) && !some(where (p_eft == deny))":
                 if (eft == Effect.Allow) {
                     this.effect = true;
+                    explainIndex = explainIndex == -1 ? currentIndex : explainIndex;
                 } else if (eft == Effect.Deny) {
                     this.effect = false;
+                    explainIndex = currentIndex;
                     this.done = true;
                 }
                 break;
@@ -56,6 +61,7 @@ public class DefaultStreamEffector implements StreamEffector {
             case "subjectPriority(p_eft) || deny":
                 if (eft != Effect.Indeterminate) {
                     this.effect = eft == Effect.Allow;
+                    explainIndex = currentIndex;
                     this.done = true;
                 }
                 break;

--- a/src/main/java/org/casbin/jcasbin/effect/DefaultStreamEffectorResult.java
+++ b/src/main/java/org/casbin/jcasbin/effect/DefaultStreamEffectorResult.java
@@ -17,14 +17,15 @@ package org.casbin.jcasbin.effect;
 public class DefaultStreamEffectorResult implements StreamEffectorResult {
     private  boolean done;
     private  boolean effect;
-
+    private int explainIndex;
     public DefaultStreamEffectorResult(){
 
 }
 
-    public DefaultStreamEffectorResult(boolean effect, boolean done) {
+    public DefaultStreamEffectorResult(boolean effect, boolean done, int explainIndex) {
         this.effect = effect;
         this.done = done;
+        this.explainIndex = explainIndex;
     }
 
     @Override
@@ -32,6 +33,7 @@ public class DefaultStreamEffectorResult implements StreamEffectorResult {
         return effect;
     }
 
+    @Override
     public boolean isDone() {
         return done;
     }
@@ -42,5 +44,14 @@ public class DefaultStreamEffectorResult implements StreamEffectorResult {
 
     public void setDone(boolean done) {
         this.done = done;
+    }
+
+    @Override
+    public int getExplainIndex() {
+        return explainIndex;
+    }
+
+    public void setExplainIndex(int explainIndex) {
+        this.explainIndex = explainIndex;
     }
 }

--- a/src/main/java/org/casbin/jcasbin/effect/StreamEffectorResult.java
+++ b/src/main/java/org/casbin/jcasbin/effect/StreamEffectorResult.java
@@ -17,4 +17,5 @@ package org.casbin.jcasbin.effect;
 public interface StreamEffectorResult {
     boolean hasEffect();
     boolean isDone();
+    int getExplainIndex();
 }

--- a/src/main/java/org/casbin/jcasbin/main/CoreEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/CoreEnforcer.java
@@ -562,7 +562,6 @@ public class CoreEnforcer {
                 if (streamEffector != null) {
                     boolean done = streamEffector.push(policyEffects[i], i, policyLen);
                     if (done) {
-                        explainIndex = i;
                         break;
                     }
                 } else {
@@ -571,6 +570,7 @@ public class CoreEnforcer {
                     }
                 }
             }
+            explainIndex = streamEffector.current().getExplainIndex();
         } else {
             policyEffects = new Effect[1];
             matcherResults = new float[1];


### PR DESCRIPTION
Fix: #337 

In RBAC with deny:
![image](https://user-images.githubusercontent.com/41513919/228478891-e8551a5d-e98f-4adb-8326-beaca91915f9.png)

add a policy `p, alice, data1, read, deny`
Hit: 
![image](https://user-images.githubusercontent.com/41513919/228479110-edcd612d-b706-4551-8976-e641c190356e.png)

