### PR TITLE
fix: optimize enforce method by moving common code before 'for' loop

### DIFF
--- a/src/test/java/org/casbin/jcasbin/main/InternalEnforcerWithDispatcherTest.java
+++ b/src/test/java/org/casbin/jcasbin/main/InternalEnforcerWithDispatcherTest.java
@@ -3,7 +3,6 @@ package org.casbin.jcasbin.main;
 import org.casbin.jcasbin.persist.Dispatcher;
 import org.junit.Before;
 import org.junit.Test;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.util.List;
 
@@ -111,7 +110,7 @@ public class InternalEnforcerWithDispatcherTest {
 
         @Override
         public void clearPolicy() {
-            throw new NotImplementedException();
+            throw new UnsupportedOperationException();
         }
 
         @Override


### PR DESCRIPTION
Fix: https://github.com/casbin/jcasbin/issues/336

Optimize enforce method by moving common code before 'for' loop. BenchmarkABACModel shows about 7 per cent decrease of average operation time.
Make InternalEnforcerWithDispatcherTest.java compile under Java 17.