### PR TITLE
feat: allow RBAC g policy to have more than 4 elements

### DIFF
--- a/src/main/java/org/casbin/jcasbin/model/Assertion.java
+++ b/src/main/java/org/casbin/jcasbin/model/Assertion.java
@@ -55,14 +55,7 @@ public class Assertion {
             if (rule.size() < count) {
                 throw new IllegalArgumentException("grouping policy elements do not meet role definition");
             }
-
-            if (count == 2) {
-                rm.addLink(rule.get(0), rule.get(1));
-            } else if (count == 3) {
-                rm.addLink(rule.get(0), rule.get(1), rule.get(2));
-            } else if (count == 4) {
-                rm.addLink(rule.get(0), rule.get(1), rule.get(2), rule.get(3));
-            }
+            rm.addLink(rule.get(0), rule.get(1), rule.subList(2, rule.size()).toArray(new String[0]));
         }
 
         Util.logPrint("Role links for: " + key);


### PR DESCRIPTION
Motivation to remove limit is to use rbac with domain while to have a couple of extra fields. Additional fields are used in #addlink-function on customised rolemanager to check whether role linking is allowed.  (https://github.com/casbin/casbin/issues/43)

