### PR TITLE
feat: add flexible EnforceContext constructor

### DIFF
--- a/src/main/java/org/casbin/jcasbin/util/EnforceContext.java
+++ b/src/main/java/org/casbin/jcasbin/util/EnforceContext.java
@@ -32,6 +32,13 @@ public class EnforceContext {
         this.rType = "r" + suffix;
     }
 
+    public EnforceContext(String pSuffix, String eSuffix, String mSuffix, String rSuffix) {
+        this.pType = "p" + pSuffix;
+        this.eType = "e" + eSuffix;
+        this.mType = "m" + mSuffix;
+        this.rType = "r" + rSuffix;
+    }
+
     public String getpType() {
         return pType;
     }


### PR DESCRIPTION
A constructor like this exists in [Node-Casbin](https://github.com/casbin/node-casbin/blob/master/src/enforceContext.ts) and is pretty convenient whenever you have multiple policy types that reuse the same effect.