### PR TITLE
feat: Expose getter and setter of aviatorEval for more customization

### DIFF
--- a/src/main/java/org/casbin/jcasbin/main/CoreEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/CoreEnforcer.java
@@ -150,6 +150,24 @@ public class CoreEnforcer {
     }
 
     /**
+     * set the aviator evaluator
+     *
+     * @param evaluator aviator evaluator
+     */
+    public void setAviatorEvaluator(AviatorEvaluatorInstance evaluator) {
+        this.aviatorEval = Objects.requireNonNull(evaluator, "The aviator evaluator cannot be null.");
+    }
+
+    /**
+     * gets the current Aviator Evaluator instance
+     *
+     * @return Aviator Evaluator instance of enforcer
+     */
+    public AviatorEvaluatorInstance getAviatorEval() {
+        return aviatorEval;
+    }
+
+    /**
      * getAdapter gets the current adapter.
      *
      * @return the adapter of the enforcer.

--- a/src/test/java/org/casbin/jcasbin/main/ManagementAPIUnitTest.java
+++ b/src/test/java/org/casbin/jcasbin/main/ManagementAPIUnitTest.java
@@ -14,6 +14,9 @@
 
 package org.casbin.jcasbin.main;
 
+import com.googlecode.aviator.AviatorEvaluator;
+import com.googlecode.aviator.AviatorEvaluatorInstance;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.List;
@@ -203,4 +206,26 @@ public class ManagementAPIUnitTest {
         testGetUsers(e, "data2_admin", asList());
         testGetUsers(e, "data3_admin", asList("eve"));
     }
+
+    @Test
+    public void should_throwsNullPointException_when_setAviatorEvaluator_given_nullInstance() {
+        // given
+        AviatorEvaluatorInstance instance = null;
+        Enforcer enforcer = new Enforcer();
+        // when
+        Assert.assertThrows("The aviator evaluator cannot be null.", NullPointerException.class,
+            () -> enforcer.setAviatorEvaluator(instance));
+    }
+
+    @Test
+    public void should_true_when_setAviatorEvaluator_given_customInstance() {
+        // given
+        AviatorEvaluatorInstance instance = AviatorEvaluator.newInstance();
+        Enforcer enforcer = new Enforcer();
+        // when
+        enforcer.setAviatorEvaluator(instance);
+        // then
+        Assert.assertEquals(instance, enforcer.getAviatorEval());
+    }
+
 }


### PR DESCRIPTION
- Expose getter and setter of aviatorEval for more customization.

For example, In concurrent processing scenarios, Enforcer uses ThreadLocal to manage multiple instances, but the AviatorEvaluatorInstance is a singleton, or custom configuration (enabling logging, performance optimization).