### PR TITLE
feat: optimize eval and error logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>4.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.googlecode.aviator</groupId>
             <artifactId>aviator</artifactId>
             <version>5.3.0</version>

--- a/src/main/java/org/casbin/jcasbin/util/BuiltInFunctions.java
+++ b/src/main/java/org/casbin/jcasbin/util/BuiltInFunctions.java
@@ -410,6 +410,7 @@ public class BuiltInFunctions {
             try {
                 res = (boolean) aviatorEval.execute(eval, env);
             } catch (Exception e) {
+                Util.logPrintfWarn("Execute 'eval' function error, nested exception is: {}", e.getMessage());
                 res = false;
             }
         } else {

--- a/src/main/java/org/casbin/jcasbin/util/Util.java
+++ b/src/main/java/org/casbin/jcasbin/util/Util.java
@@ -88,6 +88,18 @@ public class Util {
     }
 
     /**
+     * logPrintf prints the log with the format as an error.
+     *
+     * @param message the message accompanying the exception
+     * @param t       the exception (throwable) to log
+     */
+    public static void logPrintfError(String message, Throwable t) {
+        if (enableLog) {
+            LOGGER.error(message, t);
+        }
+    }
+
+    /**
      * logEnforce prints the log of Enforce.
      *
      * @param request the Enforce request.
@@ -264,8 +276,7 @@ public class Util {
                     records[i] = csvRecords.get(0).get(i).trim();
                 }
             } catch (IOException e) {
-                e.printStackTrace();
-                Util.logPrintfError("CSV parser failed to parse this line:", s);
+                Util.logPrintfError("CSV parser failed to parse this line: " + s, e);
             }
         }
         return records;

--- a/src/test/java/org/casbin/jcasbin/main/BuiltInFunctionsUnitTest.java
+++ b/src/test/java/org/casbin/jcasbin/main/BuiltInFunctionsUnitTest.java
@@ -16,12 +16,17 @@ package org.casbin.jcasbin.main;
 
 import com.googlecode.aviator.AviatorEvaluator;
 import com.googlecode.aviator.AviatorEvaluatorInstance;
+import org.casbin.jcasbin.util.BuiltInFunctions;
+import org.casbin.jcasbin.util.Util;
 import org.junit.Test;
+import org.mockito.BDDMockito;
+import org.mockito.MockedStatic;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.casbin.jcasbin.main.TestUtil.*;
+import static org.mockito.ArgumentMatchers.*;
 
 public class BuiltInFunctionsUnitTest {
 
@@ -260,4 +265,20 @@ public class BuiltInFunctionsUnitTest {
         testGlobMatch("/prefix/subprefix/foobar", "*/foo*", false);
         testGlobMatch("/prefix/subprefix/foobar", "*/foo/*", false);
     }
+
+    @Test
+    public void should_logged_when_eval_given_errorExpression() {
+        // given
+        AviatorEvaluatorInstance instance = AviatorEvaluator.getInstance();
+        Map<String, Object> env = new HashMap<>();
+
+        try (MockedStatic<Util> utilMocked = BDDMockito.mockStatic(Util.class)) {
+            utilMocked.when(() -> Util.logPrintfWarn(anyString(), anyString())).thenCallRealMethod();
+            // when
+            BuiltInFunctions.eval("error", env, instance);
+            // then
+            utilMocked.verify(() -> Util.logPrintfWarn(eq("Execute 'eval' function error, nested exception is: {}"), any()));
+        }
+    }
+
 }


### PR DESCRIPTION
- Add exception logs for `eval` functions for troubleshooting. There is no logs now, there is no way to know why it is `false` except for debugging
- Optimize ERROR logs to avoid stack loss. ERROR level logs should be printed with more details.