### PR TITLE
feat: fix g2 bug in addNamedDomainMatchingFunc()

### DIFF
--- a/src/main/java/org/casbin/jcasbin/main/CoreEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/CoreEnforcer.java
@@ -716,10 +716,10 @@ public class CoreEnforcer {
         if (rmMap.containsKey(ptype)) {
             DomainManager rm = (DomainManager) rmMap.get(ptype);
             rm.addDomainMatchingFunc(name, fn);
-            clearRmMap();
-            if (autoBuildRoleLinks) {
-                buildRoleLinks();
-            }
+//            clearRmMap();
+//            if (autoBuildRoleLinks) {
+//                buildRoleLinks();
+//            }
             return true;
         }
         return false;


### PR DESCRIPTION
After comparing the Go version, I felt that the commented out code was the main cause of NPE.

Fix: https://github.com/casbin/jcasbin/issues/362