### PR TITLE
docs: use https urls for Casbin online editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 <a href="https://casdoor.org/"><img src="https://user-images.githubusercontent.com/3787410/147868267-6ac74908-5654-4f9c-ac79-8852af9ff925.png" alt="casdoor" style="width: 50%; height: 50%"/></a>
 
-**News**: still worry about how to write the correct jCasbin policy? `Casbin online editor` is coming to help! Try it at: http://casbin.org/editor/
+**News**: still worry about how to write the correct jCasbin policy? `Casbin online editor` is coming to help! Try it at: https://casbin.org/editor/
 
 ![casbin Logo](casbin-logo.png)
 
@@ -145,7 +145,7 @@ https://casbin.org/docs/overview
 
 ## Online editor
 
-You can also use the online editor (http://casbin.org/editor/) to write your jCasbin model and policy in your web browser. It provides functionality such as `syntax highlighting` and `code completion`, just like an IDE for a programming language.
+You can also use the online editor (https://casbin.org/editor/) to write your jCasbin model and policy in your web browser. It provides functionality such as `syntax highlighting` and `code completion`, just like an IDE for a programming language.
 
 ## Tutorials
 


### PR DESCRIPTION
to make the links secure by default.