### PR TITLE
fix: sync config test case from Go to Java

### DIFF
--- a/examples/config/testini.ini
+++ b/examples/config/testini.ini
@@ -1,0 +1,48 @@
+# test config
+debug = true
+url = act.wiki
+
+; redis config
+[redis]
+redis.key = push1,push2
+
+; mysql config
+[mysql]
+mysql.dev.host = 127.0.0.1
+mysql.dev.user = root
+mysql.dev.pass = 123456
+mysql.dev.db = test
+
+mysql.master.host = 10.0.0.1
+mysql.master.user = root
+mysql.master.pass = 89dds)2$
+mysql.master.db = act
+
+; math config
+[math]
+math.i64 = 64
+math.f64 = 64.1
+
+# multi-line test
+[multi1]
+name = r.sub==p.sub \
+   && r.obj==p.obj\
+   \
+
+[multi2]
+name = r.sub==p.sub \
+   && r.obj==p.obj
+
+[multi3]
+name = r.sub==p.sub \
+   && r.obj==p.obj
+
+[multi4]
+name = \
+\
+ \
+
+[multi5]
+name = r.sub==p.sub \
+   && r.obj==p.obj\
+   \

--- a/src/test/java/org/casbin/jcasbin/main/ConfigTest.java
+++ b/src/test/java/org/casbin/jcasbin/main/ConfigTest.java
@@ -1,0 +1,41 @@
+package org.casbin.jcasbin.main;
+
+import org.casbin.jcasbin.config.Config;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class ConfigTest {
+
+    @Test
+    public void testGet() {
+        Config config = Config.newConfig("examples/config/testini.ini");
+
+        // default::key test
+        assertTrue(config.getBool("debug"));
+        assertEquals("act.wiki", config.getString("url"));
+
+        // redis::key test
+        String[] redisKeys = config.getStrings("redis::redis.key");
+        assertArrayEquals(new String[]{"push1", "push2"}, redisKeys);
+        assertEquals("127.0.0.1", config.getString("mysql::mysql.dev.host"));
+        assertEquals("10.0.0.1", config.getString("mysql::mysql.master.host"));
+        assertEquals("root", config.getString("mysql::mysql.master.user"));
+        assertEquals("89dds)2$", config.getString("mysql::mysql.master.pass"));
+
+        // math::key test
+        assertEquals(64, config.getInt("math::math.i64"));
+        assertEquals(64.1, config.getFloat("math::math.f64"), 0.0001);
+
+        config.set("other::key1", "new test key");
+        assertEquals("new test key", config.getString("other::key1"));
+
+        config.set("other::key1", "test key");
+
+        assertEquals("r.sub==p.sub && r.obj==p.obj", config.getString("multi1::name"));
+        assertEquals("r.sub==p.sub && r.obj==p.obj", config.getString("multi2::name"));
+        assertEquals("r.sub==p.sub && r.obj==p.obj", config.getString("multi3::name"));
+        assertEquals("", config.getString("multi4::name"));
+        assertEquals("r.sub==p.sub && r.obj==p.obj", config.getString("multi5::name"));
+    }
+}


### PR DESCRIPTION
sync config test case from Go to Java. Add config test in go, but not in java