### PR TITLE
feat: fix javadoc badge and comment typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codebeat badge](https://codebeat.co/badges/c17c9ee1-da42-4db3-8047-9574ad2b23b1)](https://codebeat.co/projects/github-com-casbin-jcasbin-master)
 [![GitHub Actions](https://github.com/casbin/jcasbin/workflows/build/badge.svg)](https://github.com/casbin/jcasbin/actions)
 [![codecov](https://codecov.io/gh/casbin/jcasbin/branch/master/graph/badge.svg?token=pKOEodQ3q9)](https://codecov.io/gh/casbin/jcasbin)
-[![Javadocs](https://www.javadoc.io/badge/org.casbin/jcasbin.svg)](https://www.javadoc.io/doc/org.casbin/jcasbin)
+[![javadoc](https://javadoc.io/badge2/org.casbin/jcasbin/javadoc.svg)](https://javadoc.io/doc/org.casbin/jcasbin)
 [![Maven Central](https://img.shields.io/maven-central/v/org.casbin/jcasbin.svg)](https://mvnrepository.com/artifact/org.casbin/jcasbin/latest)
 [![Release](https://img.shields.io/github/release/casbin/jcasbin.svg)](https://github.com/casbin/jcasbin/releases/latest)
 [![Discord](https://img.shields.io/discord/1022748306096537660?logo=discord&label=discord&color=5865F2)](https://discord.gg/S5UjpzGZjN)

--- a/src/test/java/org/casbin/jcasbin/main/EnforcerUnitTest.java
+++ b/src/test/java/org/casbin/jcasbin/main/EnforcerUnitTest.java
@@ -734,7 +734,7 @@ public class EnforcerUnitTest {
         e.enableAutoSave(true);
         e.addNamedMatchingFunc("g", "keyMatch4", BuiltInFunctions::keyMatch4);
 
-        // 添加 gs 角色的关系
+        // Add the relationship of gs role
         String[][] gs = new String[1001][3];
         gs[0] = new String[]{"admin@alice.co", "temp", "alice"};
         for (int i = 0; i < 1000; i++) {


### PR DESCRIPTION
Fix Javadoc: Fix some content using encoding that does not support characters.
Fix readme javadoc.The link format of badge has changed.

[![Javadocs](https://www.javadoc.io/badge/org.casbin/jcasbin.svg)](https://www.javadoc.io/doc/org.casbin/jcasbin)    -->
[![javadoc](https://javadoc.io/badge2/org.casbin/jcasbin/javadoc.svg)](https://javadoc.io/doc/org.casbin/jcasbin)

Fix: https://github.com/casbin/jcasbin/issues/429
