### PR TITLE
feat: fix potential null pointer issue in loadPolicyLine()

### DIFF
--- a/src/main/java/org/casbin/jcasbin/persist/Helper.java
+++ b/src/main/java/org/casbin/jcasbin/persist/Helper.java
@@ -19,6 +19,7 @@ import org.casbin.jcasbin.model.Model;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static org.casbin.jcasbin.util.Util.splitCommaDelimited;
 
@@ -40,7 +41,14 @@ public class Helper {
 
         String key = tokens[0];
         String sec = key.substring(0, 1);
-        Assertion ast = model.model.get(sec).get(key);
+        Map<String, Assertion> astMap = model.model.get(sec);
+        if(astMap == null) {
+            return;
+        }
+        Assertion ast = astMap.get(key);
+        if(ast == null) {
+            return;
+        }
         List<String> policy = Arrays.asList(Arrays.copyOfRange(tokens, 1, tokens.length));
         ast.policy.add(policy);
         ast.policyIndex.put(policy.toString(), ast.policy.size() - 1);

--- a/src/main/java/org/casbin/jcasbin/persist/file_adapter/FileAdapter.java
+++ b/src/main/java/org/casbin/jcasbin/persist/file_adapter/FileAdapter.java
@@ -154,7 +154,7 @@ public class FileAdapter implements Adapter {
         }
         try {
             List<String> lines = IOUtils.readLines(new FileInputStream(filePath), Charset.forName("UTF-8"));
-            lines.remove(ruleText);
+            lines.removeIf(line -> line.replaceAll("\\s", "").equals(ruleText.replaceAll("\\s", "")));
             savePolicyFile(String.join("\n", lines));
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
To fix the issue of NPE caused by non printing characters, users need to ensure the correctness of the policy file format. Although non printing characters may not cause errors, they may differ from users' expectations. Policy files allow spaces to appear.
Fix: #437