### PR TITLE
fix: Use cache with SyncedCachedEnforcer

### DIFF
--- a/src/main/java/org/casbin/jcasbin/main/SyncedCachedEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/SyncedCachedEnforcer.java
@@ -121,7 +121,7 @@ public class SyncedCachedEnforcer extends SyncedEnforcer{
      * @return The result of the enforcement check.
      */
     public boolean enforce(Object... rvals) {
-        if (enableCache.get()) {
+        if (!enableCache.get()) {
             return super.enforce(rvals);
         }
 


### PR DESCRIPTION
SyncedCachedEnforcer never uses the cache for reads because of a boolean logic error.