### PR TITLE
feat:update addNamedGroupingPoliciesEx() and addGroupingPoliciesEx() and Unit Test these methods.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
                 <!-- Automatically close and deploy from OSSRH -->
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.6.0</version>
+                <version>0.4.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>ossrh</publishingServerId>

--- a/src/main/java/org/casbin/jcasbin/main/ManagementEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/ManagementEnforcer.java
@@ -591,6 +591,30 @@ public class ManagementEnforcer extends InternalEnforcer {
     }
 
     /**
+     * addGroupingPoliciesEx adds role inheritance rules to the current policy.
+     * If the rule already exists, the rule will not be added.
+     * But unlike addGroupingPolicies, other non-existent rules are added instead of returning false directly.
+     *
+     * @param rules the "g" policy rules, ptype "g" is implicitly used.
+     * @return succeeds or not.
+     */
+    public boolean addGroupingPoliciesEx(List<List<String>> rules) {
+        return addNamedGroupingPoliciesEx("g", rules);
+    }
+
+    /**
+     * addGroupingPoliciesEx adds role inheritance rules to the current policy.
+     * If the rule already exists, the rule will not be added.
+     * But unlike addGroupingPolicies, other non-existent rules are added instead of returning false directly.
+     *
+     * @param rules the "g" policy rules, ptype "g" is implicitly used.
+     * @return succeeds or not.
+     */
+    public boolean addGroupingPoliciesEx(String[][] rules) {
+        return addGroupingPoliciesEx(Arrays.stream(rules).map(Arrays::asList).collect(Collectors.toList()));
+    }
+
+    /**
      * addNamedGroupingPolicy adds a named role inheritance rule to the current policy.
      * If the rule already exists, the function returns false and the rule will not be added.
      * Otherwise the function returns true by adding the new rule.
@@ -643,6 +667,32 @@ public class ManagementEnforcer extends InternalEnforcer {
      */
     public boolean addNamedGroupingPolicies(String ptype, String[][] rules) {
         return addNamedGroupingPolicies(ptype, Arrays.stream(rules).map(Arrays::asList).collect(Collectors.toList()));
+    }
+
+    /**
+     * addNamedGroupingPoliciesEx adds named role inheritance rules to the current policy.
+     * If the rule already exists, the rule will not be added.
+     * But unlike addNamedGroupingPolicies, other non-existent rules are added instead of returning false directly.
+     *
+     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @param rules the "g" policy rules.
+     * @return succeeds or not.
+     */
+    public boolean addNamedGroupingPoliciesEx(String ptype, List<List<String>> rules) {
+        return addPolicies("g", ptype, rules, true);
+    }
+
+    /**
+     * addNamedGroupingPoliciesEx adds named role inheritance rules to the current policy.
+     * If the rule already exists, the rule will not be added.
+     * But unlike addNamedGroupingPolicies, other non-existent rules are added instead of returning false directly.
+     *
+     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @param rules the "g" policy rules.
+     * @return succeeds or not.
+     */
+    public boolean addNamedGroupingPoliciesEx(String ptype, String[][] rules) {
+        return addNamedGroupingPoliciesEx(ptype, Arrays.stream(rules).map(Arrays::asList).collect(Collectors.toList()));
     }
 
     /**

--- a/src/main/java/org/casbin/jcasbin/main/SyncedEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/SyncedEnforcer.java
@@ -886,6 +886,32 @@ public class SyncedEnforcer extends Enforcer {
     }
 
     /**
+     * addGroupingPoliciesEx adds role inheritance rules to the current policy.
+     * If the rule already exists, the rule will not be added.
+     * But unlike addGroupingPolicies, other non-existent rules are added instead of returning false directly.
+     *
+     * @param rules the "g" policy rules, ptype "g" is implicitly used.
+     * @return succeeds or not.
+     */
+    @Override
+    public boolean addGroupingPoliciesEx(List<List<String>> rules) {
+        return runSynchronized(() -> super.addGroupingPoliciesEx(rules), READ_WRITE_LOCK.writeLock());
+    }
+
+    /**
+     * addGroupingPoliciesEx adds role inheritance rules to the current policy.
+     * If the rule already exists, the rule will not be added.
+     * But unlike addGroupingPolicies, other non-existent rules are added instead of returning false directly.
+     *
+     * @param rules the "g" policy rules, ptype "g" is implicitly used.
+     * @return succeeds or not.
+     */
+    @Override
+    public boolean addGroupingPoliciesEx(String[][] rules) {
+        return runSynchronized(() -> super.addGroupingPoliciesEx(rules), READ_WRITE_LOCK.writeLock());
+    }
+
+    /**
      * addNamedGroupingPolicy adds a named role inheritance rule to the current policy.
      * If the rule already exists, the function returns false and the rule will not be added.
      * Otherwise the function returns true by adding the new rule.
@@ -950,6 +976,34 @@ public class SyncedEnforcer extends Enforcer {
     @Override
     public boolean removeGroupingPolicy(List<String> params) {
         return runSynchronized(() -> super.removeGroupingPolicy(params), READ_WRITE_LOCK.writeLock());
+    }
+
+    /**
+     * addNamedGroupingPoliciesEx adds named role inheritance rules to the current policy.
+     * If the rule already exists, the rule will not be added.
+     * But unlike addNamedGroupingPolicies, other non-existent rules are added instead of returning false directly.
+     *
+     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @param rules the "g" policy rules.
+     * @return succeeds or not.
+     */
+    @Override
+    public boolean addNamedGroupingPoliciesEx(String ptype, List<List<String>> rules) {
+        return runSynchronized(() -> super.addNamedGroupingPoliciesEx(ptype, rules), READ_WRITE_LOCK.writeLock());
+    }
+
+    /**
+     * addNamedGroupingPoliciesEx adds named role inheritance rules to the current policy.
+     * If the rule already exists, the rule will not be added.
+     * But unlike addNamedGroupingPolicies, other non-existent rules are added instead of returning false directly.
+     *
+     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @param rules the "g" policy rules.
+     * @return succeeds or not.
+     */
+    @Override
+    public boolean addNamedGroupingPoliciesEx(String ptype, String[][] rules) {
+        return runSynchronized(() -> super.addNamedGroupingPoliciesEx(ptype, rules), READ_WRITE_LOCK.writeLock());
     }
 
     /**

--- a/src/test/java/org/casbin/jcasbin/main/AddNamedGroupingPoliciesExTest.java
+++ b/src/test/java/org/casbin/jcasbin/main/AddNamedGroupingPoliciesExTest.java
@@ -1,0 +1,125 @@
+// Copyright 2024 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.casbin.jcasbin.main;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.casbin.jcasbin.main.TestUtil.*;
+
+/**
+ * Test for addNamedGroupingPoliciesEx method implementation
+ */
+public class AddNamedGroupingPoliciesExTest {
+
+    @Test
+    public void testAddNamedGroupingPoliciesEx() {
+        Enforcer e = new Enforcer("examples/rbac_model.conf", "examples/rbac_policy.csv");
+
+        // Test basic functionality
+        String[][] rules = {
+            {"alice", "admin"},
+            {"bob", "user"},
+            {"charlie", "moderator"}
+        };
+
+        // Add rules for the first time - should succeed
+        Assert.assertTrue(e.addNamedGroupingPoliciesEx("g", rules));
+
+        // Verify roles are added correctly
+        testGetRoles(e, "alice", asList("data2_admin", "admin"));
+        testGetRoles(e, "bob", asList("user"));
+        testGetRoles(e, "charlie", asList("moderator"));
+
+        // Test Ex behavior - add some duplicate and some new rules
+        String[][] mixedRules = {
+            {"alice", "admin"},      // duplicate - should be ignored
+            {"bob", "user"},         // duplicate - should be ignored
+            {"david", "guest"},      // new rule - should be added
+            {"eve", "supervisor"}    // new rule - should be added
+        };
+
+        // addNamedGroupingPoliciesEx should succeed even with duplicates
+        Assert.assertTrue(e.addNamedGroupingPoliciesEx("g", mixedRules));
+
+        // Verify only new rules were added
+        testGetRoles(e, "alice", asList("data2_admin", "admin")); // no duplicates
+        testGetRoles(e, "bob", asList("user"));                   // no duplicates
+        testGetRoles(e, "david", asList("guest"));                // new rule added
+        testGetRoles(e, "eve", asList("supervisor"));             // new rule added
+
+        // Test with List<List<String>> version
+        List<List<String>> listRules = asList(
+            asList("alice", "admin"),     // duplicate
+            asList("frank", "editor")     // new
+        );
+
+        Assert.assertTrue(e.addNamedGroupingPoliciesEx("g", listRules));
+        testGetRoles(e, "alice", asList("data2_admin", "admin")); // no duplicates
+        testGetRoles(e, "frank", asList("editor"));               // new rule added
+    }
+
+    @Test
+    public void testAddGroupingPoliciesEx() {
+        Enforcer e = new Enforcer("examples/rbac_model.conf", "examples/rbac_policy.csv");
+
+        // Test basic functionality with default "g" ptype
+        String[][] rules = {
+            {"alice", "admin"},
+            {"bob", "user"}
+        };
+
+        Assert.assertTrue(e.addGroupingPoliciesEx(rules));
+        testGetRoles(e, "alice", asList("data2_admin", "admin"));
+        testGetRoles(e, "bob", asList("user"));
+
+        // Test with duplicates
+        String[][] duplicateRules = {
+            {"alice", "admin"},    // duplicate
+            {"charlie", "guest"}   // new
+        };
+
+        Assert.assertTrue(e.addGroupingPoliciesEx(duplicateRules));
+        testGetRoles(e, "alice", asList("data2_admin", "admin")); // no duplicates
+        testGetRoles(e, "charlie", asList("guest"));              // new rule added
+    }
+
+    @Test
+    public void testSyncedAddNamedGroupingPoliciesEx() {
+        SyncedEnforcer e = new SyncedEnforcer("examples/rbac_model.conf", "examples/rbac_policy.csv");
+
+        String[][] rules = {
+            {"alice", "admin"},
+            {"bob", "user"}
+        };
+
+        Assert.assertTrue(e.addNamedGroupingPoliciesEx("g", rules));
+        testGetRoles(e, "alice", asList("data2_admin", "admin"));
+        testGetRoles(e, "bob", asList("user"));
+
+        // Test with duplicates
+        String[][] duplicateRules = {
+            {"alice", "admin"},    // duplicate
+            {"charlie", "guest"}   // new
+        };
+
+        Assert.assertTrue(e.addNamedGroupingPoliciesEx("g", duplicateRules));
+        testGetRoles(e, "alice", asList("data2_admin", "admin")); // no duplicates
+        testGetRoles(e, "charlie", asList("guest"));              // new rule added
+    }
+}

--- a/src/test/java/org/casbin/jcasbin/main/ManagementAPIUnitTest.java
+++ b/src/test/java/org/casbin/jcasbin/main/ManagementAPIUnitTest.java
@@ -173,6 +173,26 @@ public class ManagementAPIUnitTest {
         e.removeNamedGroupingPolicies("g", groupingRules);
         e.removeNamedGroupingPolicies("g", groupingRules);
 
+        // Test addNamedGroupingPoliciesEx
+        String[][] groupingRulesEx = {
+            {"ham", "data4_admin"},
+            {"jack", "data5_admin"},
+            {"duplicate", "data6_admin"}
+        };
+
+        // First add some duplicate rules to test Ex behavior
+        e.addNamedGroupingPolicy("g", "ham", "data4_admin");
+        testGetRoles(e, "ham", asList("data4_admin"));
+
+        // addNamedGroupingPoliciesEx should succeed even with duplicates
+        Assert.assertTrue(e.addNamedGroupingPoliciesEx("g", groupingRulesEx));
+        testGetRoles(e, "ham", asList("data4_admin")); // Still only one rule
+        testGetRoles(e, "jack", asList("data5_admin")); // New rule added
+        testGetRoles(e, "duplicate", asList("data6_admin")); // New rule added
+
+        // Clean up
+        e.removeNamedGroupingPolicies("g", groupingRulesEx);
+
         testGetRoles(e, "alice", asList());
         testGetRoles(e, "bob", asList("data1_admin"));
         testGetRoles(e, "eve", asList("data3_admin"));


### PR DESCRIPTION
Fix: https://github.com/casbin/jcasbin/issues/461

Add two methods content that addNamedGroupingPoliciesEx() and addGroupingPoliciesEx() . At the same time,unit tests were conducted and update pom central-publishing-maven-plugin to appropriate version(0.4.0).