### PR TITLE
﻿﻿chore: port GetUsers/GetNamedUsers API from Go to Java

### DIFF
--- a/src/main/java/org/casbin/jcasbin/main/ManagementEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/ManagementEnforcer.java
@@ -126,6 +126,44 @@ public class ManagementEnforcer extends InternalEnforcer {
     }
 
     /**
+     * getUsers gets the list of users that show up in the current policy.
+     * Users are subjects that are not roles.
+     *
+     * @return all users in policy and grouping rules, excluding roles.
+     */
+    public List<String> getUsers() {
+        List<String> pSubjects = getAllSubjects();
+        List<String> gSubjects = model.getValuesForFieldInPolicyAllTypes("g", 0);
+        List<String> roles = getAllRoles();
+
+        List<String> allSubjects = new ArrayList<>(pSubjects);
+        allSubjects.addAll(gSubjects);
+        allSubjects = Util.arrayRemoveDuplicates(allSubjects);
+
+        return Util.setSubtract(allSubjects, roles);
+    }
+
+    /**
+     * getNamedUsers gets the list of users that show up in the current named policy.
+     * Users are subjects that are not roles.
+     *
+     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @return all users in the specified policy type, excluding roles.
+     */
+    public List<String> getNamedUsers(String ptype) {
+        int subjectIndex = model.getFieldIndex(ptype, "sub");
+        List<String> pSubjects = model.getValuesForFieldInPolicy("p", ptype, subjectIndex);
+        List<String> gSubjects = model.getValuesForFieldInPolicyAllTypes("g", 0);
+        List<String> roles = getAllRoles();
+
+        List<String> allSubjects = new ArrayList<>(pSubjects);
+        allSubjects.addAll(gSubjects);
+        allSubjects = Util.arrayRemoveDuplicates(allSubjects);
+
+        return Util.setSubtract(allSubjects, roles);
+    }
+
+    /**
      * getPolicy gets all the authorization rules in the policy.
      *
      * @return all the "p" policy rules.

--- a/src/main/java/org/casbin/jcasbin/main/ManagementEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/ManagementEnforcer.java
@@ -126,28 +126,14 @@ public class ManagementEnforcer extends InternalEnforcer {
     }
 
     /**
-     * getUsers gets the list of users that show up in the current policy.
+     * getAllUsers gets the list of users that show up in the current policy.
      * Users are subjects that are not roles (i.e., subjects that do not appear
      * as the second element in any grouping policy).
      *
      * @return all users in policy, excluding roles.
      */
-    public List<String> getUsers() {
+    public List<String> getAllUsers() {
         List<String> subjects = getAllSubjects();
-        List<String> roles = getAllRoles();
-        return Util.setSubtract(subjects, roles);
-    }
-
-    /**
-     * getNamedUsers gets the list of users that show up in the current named policy.
-     * Users are subjects that are not roles.
-     *
-     * @param ptype the policy type, can be "p", "p2", "p3", ..
-     * @return all users in the specified policy type, excluding roles.
-     */
-    public List<String> getNamedUsers(String ptype) {
-        int subjectIndex = model.getFieldIndex(ptype, "sub");
-        List<String> subjects = model.getValuesForFieldInPolicy("p", ptype, subjectIndex);
         List<String> roles = getAllRoles();
         return Util.setSubtract(subjects, roles);
     }

--- a/src/main/java/org/casbin/jcasbin/main/ManagementEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/ManagementEnforcer.java
@@ -127,20 +127,15 @@ public class ManagementEnforcer extends InternalEnforcer {
 
     /**
      * getUsers gets the list of users that show up in the current policy.
-     * Users are subjects that are not roles.
+     * Users are subjects that are not roles (i.e., subjects that do not appear
+     * as the second element in any grouping policy).
      *
-     * @return all users in policy and grouping rules, excluding roles.
+     * @return all users in policy, excluding roles.
      */
     public List<String> getUsers() {
-        List<String> pSubjects = getAllSubjects();
-        List<String> gSubjects = model.getValuesForFieldInPolicyAllTypes("g", 0);
+        List<String> subjects = getAllSubjects();
         List<String> roles = getAllRoles();
-
-        List<String> allSubjects = new ArrayList<>(pSubjects);
-        allSubjects.addAll(gSubjects);
-        allSubjects = Util.arrayRemoveDuplicates(allSubjects);
-
-        return Util.setSubtract(allSubjects, roles);
+        return Util.setSubtract(subjects, roles);
     }
 
     /**
@@ -152,15 +147,9 @@ public class ManagementEnforcer extends InternalEnforcer {
      */
     public List<String> getNamedUsers(String ptype) {
         int subjectIndex = model.getFieldIndex(ptype, "sub");
-        List<String> pSubjects = model.getValuesForFieldInPolicy("p", ptype, subjectIndex);
-        List<String> gSubjects = model.getValuesForFieldInPolicyAllTypes("g", 0);
+        List<String> subjects = model.getValuesForFieldInPolicy("p", ptype, subjectIndex);
         List<String> roles = getAllRoles();
-
-        List<String> allSubjects = new ArrayList<>(pSubjects);
-        allSubjects.addAll(gSubjects);
-        allSubjects = Util.arrayRemoveDuplicates(allSubjects);
-
-        return Util.setSubtract(allSubjects, roles);
+        return Util.setSubtract(subjects, roles);
     }
 
     /**

--- a/src/main/java/org/casbin/jcasbin/main/SyncedEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/SyncedEnforcer.java
@@ -406,6 +406,29 @@ public class SyncedEnforcer extends Enforcer {
     }
 
     /**
+     * getUsers gets the list of users that show up in the current policy.
+     * Users are subjects that are not roles.
+     *
+     * @return all users in policy and grouping rules, excluding roles.
+     */
+    @Override
+    public List<String> getUsers() {
+        return runSynchronized(super::getUsers, getReadWriteLock().readLock());
+    }
+
+    /**
+     * getNamedUsers gets the list of users that show up in the current named policy.
+     * Users are subjects that are not roles.
+     *
+     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @return all users in the specified policy type, excluding roles.
+     */
+    @Override
+    public List<String> getNamedUsers(String ptype) {
+        return runSynchronized(() -> super.getNamedUsers(ptype), getReadWriteLock().readLock());
+    }
+
+    /**
      * getPolicy gets all the authorization rules in the policy.
      *
      * @return all the "p" policy rules.

--- a/src/main/java/org/casbin/jcasbin/main/SyncedEnforcer.java
+++ b/src/main/java/org/casbin/jcasbin/main/SyncedEnforcer.java
@@ -406,26 +406,14 @@ public class SyncedEnforcer extends Enforcer {
     }
 
     /**
-     * getUsers gets the list of users that show up in the current policy.
+     * getAllUsers gets the list of users that show up in the current policy.
      * Users are subjects that are not roles.
      *
-     * @return all users in policy and grouping rules, excluding roles.
+     * @return all users in policy rules, excluding roles.
      */
     @Override
-    public List<String> getUsers() {
-        return runSynchronized(super::getUsers, getReadWriteLock().readLock());
-    }
-
-    /**
-     * getNamedUsers gets the list of users that show up in the current named policy.
-     * Users are subjects that are not roles.
-     *
-     * @param ptype the policy type, can be "p", "p2", "p3", ..
-     * @return all users in the specified policy type, excluding roles.
-     */
-    @Override
-    public List<String> getNamedUsers(String ptype) {
-        return runSynchronized(() -> super.getNamedUsers(ptype), getReadWriteLock().readLock());
+    public List<String> getAllUsers() {
+        return runSynchronized(super::getAllUsers, getReadWriteLock().readLock());
     }
 
     /**

--- a/src/main/java/org/casbin/jcasbin/model/Model.java
+++ b/src/main/java/org/casbin/jcasbin/model/Model.java
@@ -470,4 +470,54 @@ public class Model extends Policy {
             s.append(String.format("%s = %s\n", sec, value));
         }
     }
+
+    /**
+     * getValuesForFieldInPolicyAllTypes gets all values for a field for all rules
+     * across all policy types in a section. Duplicated values are removed.
+     *
+     * @param sec the section, "p" or "g".
+     * @param fieldIndex the policy rule's index.
+     * @return all field values across all ptypes.
+     */
+    public List<String> getValuesForFieldInPolicyAllTypes(String sec, int fieldIndex) {
+        List<String> values = new ArrayList<>();
+
+        Map<String, Assertion> section = model.get(sec);
+        if (section == null) {
+            return values;
+        }
+
+        for (Assertion assertion : section.values()) {
+            for (List<String> rule : assertion.policy) {
+                if (fieldIndex < rule.size()) {
+                    values.add(rule.get(fieldIndex));
+                }
+            }
+        }
+
+        return Util.arrayRemoveDuplicates(values);
+    }
+
+    /**
+     * getFieldIndex returns the index of a field in a policy type.
+     * For example, given ptype="p" and field="sub", returns the index
+     * where "p_sub" appears in the tokens array.
+     *
+     * @param ptype the policy type, e.g., "p", "p2"
+     * @param field the field name, e.g., "sub", "obj", "act"
+     * @return the index of the field in the policy rule, or 0 if not found
+     */
+    public int getFieldIndex(String ptype, String field) {
+        String pattern = ptype + "_" + field;
+        Assertion ast = model.get("p").get(ptype);
+        if (ast == null || ast.tokens == null) {
+            return 0;
+        }
+        for (int i = 0; i < ast.tokens.length; i++) {
+            if (pattern.equals(ast.tokens[i])) {
+                return i;
+            }
+        }
+        return 0;
+    }
 }

--- a/src/main/java/org/casbin/jcasbin/model/Model.java
+++ b/src/main/java/org/casbin/jcasbin/model/Model.java
@@ -505,19 +505,23 @@ public class Model extends Policy {
      *
      * @param ptype the policy type, e.g., "p", "p2"
      * @param field the field name, e.g., "sub", "obj", "act"
-     * @return the index of the field in the policy rule, or 0 if not found
+     * @return the index of the field in the policy rule, or -1 if not found
      */
     public int getFieldIndex(String ptype, String field) {
         String pattern = ptype + "_" + field;
-        Assertion ast = model.get("p").get(ptype);
+        Map<String, Assertion> pSection = model.get("p");
+        if (pSection == null) {
+            return -1;
+        }
+        Assertion ast = pSection.get(ptype);
         if (ast == null || ast.tokens == null) {
-            return 0;
+            return -1;
         }
         for (int i = 0; i < ast.tokens.length; i++) {
             if (pattern.equals(ast.tokens[i])) {
                 return i;
             }
         }
-        return 0;
+        return -1;
     }
 }

--- a/src/main/java/org/casbin/jcasbin/util/Util.java
+++ b/src/main/java/org/casbin/jcasbin/util/Util.java
@@ -388,4 +388,29 @@ public class Util {
             return false;
         }
     }
+
+    /**
+     * setSubtract returns elements in list A that are not in list B.
+     * Preserves order from list A.
+     *
+     * @param a the first list (base)
+     * @param b the second list (subtrahend)
+     * @return a - b (elements in A but not in B)
+     */
+    public static List<String> setSubtract(List<String> a, List<String> b) {
+        if (a == null) {
+            a = new ArrayList<>();
+        }
+        if (b == null) {
+            b = new ArrayList<>();
+        }
+        Set<String> bSet = new HashSet<>(b);
+        List<String> result = new ArrayList<>();
+        for (String item : a) {
+            if (!bSet.contains(item)) {
+                result.add(item);
+            }
+        }
+        return result;
+    }
 }

--- a/src/test/java/org/casbin/jcasbin/main/ManagementAPIUnitTest.java
+++ b/src/test/java/org/casbin/jcasbin/main/ManagementAPIUnitTest.java
@@ -16,6 +16,7 @@ package org.casbin.jcasbin.main;
 
 import com.googlecode.aviator.AviatorEvaluator;
 import com.googlecode.aviator.AviatorEvaluatorInstance;
+import org.casbin.jcasbin.util.Util;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -296,6 +297,52 @@ public class ManagementAPIUnitTest {
         enforcer.setAviatorEvaluator(instance);
         // then
         assertEquals(enforcer.getAviatorEval(), instance);
+    }
+
+    @Test
+    public void testGetUsersAPI() {
+        Enforcer e = new Enforcer("examples/rbac_model.conf", "examples/rbac_policy.csv");
+
+        testGetAllSubjectsUtil(e, asList("alice", "bob", "data2_admin"));
+        testGetAllRolesUtil(e, asList("data2_admin"));
+        testGetUsersUtil(e, asList("alice", "bob"));
+        testGetNamedUsersUtil(e, "p", asList("alice", "bob"));
+    }
+
+    private void testGetAllSubjectsUtil(Enforcer enforcer, List<String> res) {
+        List<String> myRes = enforcer.getAllSubjects();
+        Util.logPrint("All subjects: " + myRes);
+
+        if (!Util.setEquals(res, myRes)) {
+            Assert.fail("All subjects: " + myRes + ", supposed to be " + res);
+        }
+    }
+
+    private void testGetAllRolesUtil(Enforcer enforcer, List<String> res) {
+        List<String> myRes = enforcer.getAllRoles();
+        Util.logPrint("All roles: " + myRes);
+
+        if (!Util.setEquals(res, myRes)) {
+            Assert.fail("All roles: " + myRes + ", supposed to be " + res);
+        }
+    }
+
+    private void testGetUsersUtil(Enforcer enforcer, List<String> res) {
+        List<String> myRes = enforcer.getUsers();
+        Util.logPrint("Users: " + myRes);
+
+        if (!Util.setEquals(res, myRes)) {
+            Assert.fail("Users: " + myRes + ", supposed to be " + res);
+        }
+    }
+
+    private void testGetNamedUsersUtil(Enforcer enforcer, String ptype, List<String> res) {
+        List<String> myRes = enforcer.getNamedUsers(ptype);
+        Util.logPrint("Named users (" + ptype + "): " + myRes);
+
+        if (!Util.setEquals(res, myRes)) {
+            Assert.fail("Named users (" + ptype + "): " + myRes + ", supposed to be " + res);
+        }
     }
 
 }

--- a/src/test/java/org/casbin/jcasbin/main/ManagementAPIUnitTest.java
+++ b/src/test/java/org/casbin/jcasbin/main/ManagementAPIUnitTest.java
@@ -301,12 +301,45 @@ public class ManagementAPIUnitTest {
 
     @Test
     public void testGetUsersAPI() {
+        // 1. Basic RBAC: alice and bob are users, data2_admin is a role
         Enforcer e = new Enforcer("examples/rbac_model.conf", "examples/rbac_policy.csv");
-
         testGetAllSubjectsUtil(e, asList("alice", "bob", "data2_admin"));
         testGetAllRolesUtil(e, asList("data2_admin"));
-        testGetUsersUtil(e, asList("alice", "bob"));
-        testGetNamedUsersUtil(e, "p", asList("alice", "bob"));
+        testGetAllUsersUtil(e, asList("alice", "bob"));
+
+        // 2. Add user "admin" that appears in both policy (as subject) and grouping (as role target)
+        // getAllUsers computes: subjects (from p) - roles (from g, column 1)
+        // admin is added as a policy subject and also assigned to role "root"
+        e.addPolicy("admin", "data1", "read");
+        e.addGroupingPolicy("admin", "root");
+        testGetAllSubjectsUtil(e, asList("alice", "bob", "data2_admin", "admin"));
+        testGetAllRolesUtil(e, asList("data2_admin", "root"));
+        testGetAllUsersUtil(e, asList("alice", "bob", "admin")); // admin is user since it's in p, not in g column 1
+        e.removePolicy("admin", "data1", "read");
+        e.removeGroupingPolicy("admin", "root");
+
+        // 3. Add regular user "eve" who is only in policy (not a role in any grouping)
+        e.addPolicy("eve", "data3", "read");
+        testGetAllSubjectsUtil(e, asList("alice", "bob", "data2_admin", "eve"));
+        testGetAllRolesUtil(e, asList("data2_admin"));
+        testGetAllUsersUtil(e, asList("alice", "bob", "eve")); // eve is user since she's not in g column 1
+        e.removePolicy("eve", "data3", "read");
+
+        // 4. Clear all policies - verify empty results
+        e.clearPolicy();
+        testGetAllSubjectsUtil(e, asList());
+        testGetAllRolesUtil(e, asList());
+        testGetAllUsersUtil(e, asList());
+
+        // 5. Add new user and role relationship: user1 is a member of role "member"
+        // getAllSubjects: ["user1"] - from p column 0
+        // getAllRoles: ["member"] - from g column 1 (the second element in grouping)
+        // getAllUsers: ["user1"] = subjects - roles
+        e.addPolicy("user1", "data1", "read");
+        e.addGroupingPolicy("user1", "member");
+        testGetAllSubjectsUtil(e, asList("user1"));
+        testGetAllRolesUtil(e, asList("member"));
+        testGetAllUsersUtil(e, asList("user1"));
     }
 
     private void testGetAllSubjectsUtil(Enforcer enforcer, List<String> res) {
@@ -327,21 +360,12 @@ public class ManagementAPIUnitTest {
         }
     }
 
-    private void testGetUsersUtil(Enforcer enforcer, List<String> res) {
-        List<String> myRes = enforcer.getUsers();
-        Util.logPrint("Users: " + myRes);
+    private void testGetAllUsersUtil(Enforcer enforcer, List<String> res) {
+        List<String> myRes = enforcer.getAllUsers();
+        Util.logPrint("All users: " + myRes);
 
         if (!Util.setEquals(res, myRes)) {
-            Assert.fail("Users: " + myRes + ", supposed to be " + res);
-        }
-    }
-
-    private void testGetNamedUsersUtil(Enforcer enforcer, String ptype, List<String> res) {
-        List<String> myRes = enforcer.getNamedUsers(ptype);
-        Util.logPrint("Named users (" + ptype + "): " + myRes);
-
-        if (!Util.setEquals(res, myRes)) {
-            Assert.fail("Named users (" + ptype + "): " + myRes + ", supposed to be " + res);
+            Assert.fail("All users: " + myRes + ", supposed to be " + res);
         }
     }
 


### PR DESCRIPTION
## Background

Issue: https://github.com/apache/casbin/issues/1621

This PR ports the users/roles separation feature (implemented in Go PR #1652) to the Java version,
ensuring API and implementation logic are synchronized across languages.

## Changes

### New APIs
- `getUsers()` - Get all users in the current policy
- `getNamedUsers(ptype)` - Get all users in the specified policy type

**Algorithm** (consistent with final Go implementation):
Users = subjects from "p" - roles from "g"

### Ported Utilities
| Go | Java |
|----|------|
| `GetFieldIndex` | `Model.getFieldIndex(ptype, field)` |
| `SetSubtract` | `Util.setSubtract()` |

## Implementation Note

The initial port used the early-branch algorithm that included "g" column 0 entities.
This has been corrected to match the final Go version (PR #1652).

## Files Changed

- `Model.java` - Add `getFieldIndex()` method
- `Util.java` - Add `setSubtract()` method
- `ManagementEnforcer.java` - Add `getUsers()` and `getNamedUsers(ptype)`
- `SyncedEnforcer.java` - Add thread-safe wrappers

## Testing
- ManagementAPIUnitTest passes
- Behavior consistent with Go's GetAllUsers