### PR TITLE
fix: replace semantic release with snapshot workflows

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -22,11 +22,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-          server-id: ossrh
-          server-username: OSSRH_JIRA_USERNAME
-          server-password: OSSRH_JIRA_PASSWORD
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: GPG_PASSPHRASE
 
       - name: Build with Maven
         run: mvn clean test cobertura:cobertura
@@ -35,19 +30,3 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: 20
-
-      - name: Semantic Release
-        run: |
-          npm install -g @conveyal/maven-semantic-release semantic-release
-          semantic-release --prepare @conveyal/maven-semantic-release --publish @semantic-release/github,@conveyal/maven-semantic-release --verify-conditions @semantic-release/github,@conveyal/maven-semantic-release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GPG_KEY_NAME: ${{ secrets.GPG_KEY_NAME }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          OSSRH_JIRA_USERNAME: ${{ secrets.OSSRH_JIRA_USERNAME }}
-          OSSRH_JIRA_PASSWORD: ${{ secrets.OSSRH_JIRA_PASSWORD }}

--- a/.github/workflows/maven-snapshot.yml
+++ b/.github/workflows/maven-snapshot.yml
@@ -1,0 +1,70 @@
+name: Publish Maven Snapshot
+
+on:
+  workflow_run:
+    workflows:
+      - build
+    types:
+      - completed
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish-maven-snapshot:
+    if: ${{ github.repository == 'apache/casbin-jcasbin' && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 8
+          server-id: ossrh
+          server-username: OSSRH_JIRA_USERNAME
+          server-password: OSSRH_JIRA_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: GPG_PASSPHRASE
+
+      - name: Compute Maven snapshot version
+        id: snapshot
+        run: |
+          LATEST_RELEASE_TAG="$(
+            git tag --list 'v*' |
+              grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' |
+              sort -V |
+              tail -n 1
+          )"
+
+          if [ -z "${LATEST_RELEASE_TAG}" ]; then
+            SNAPSHOT_VERSION="0.1.0-SNAPSHOT"
+          else
+            RELEASE_VERSION="${LATEST_RELEASE_TAG#v}"
+            MAJOR="${RELEASE_VERSION%%.*}"
+            REST="${RELEASE_VERSION#*.}"
+            MINOR="${REST%%.*}"
+            NEXT_MINOR="$((MINOR + 1))"
+            SNAPSHOT_VERSION="${MAJOR}.${NEXT_MINOR}.0-SNAPSHOT"
+          fi
+
+          echo "version=${SNAPSHOT_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "Computed Maven snapshot version: ${SNAPSHOT_VERSION}"
+
+      - name: Publish Maven snapshot
+        run: |
+          mvn -B org.codehaus.mojo:versions-maven-plugin:2.16.2:set -DnewVersion="${{ steps.snapshot.outputs.version }}" -DgenerateBackupPoms=false
+          mvn -B deploy -DskipTests
+        env:
+          GPG_KEY_NAME: ${{ secrets.GPG_KEY_NAME }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          OSSRH_JIRA_USERNAME: ${{ secrets.OSSRH_JIRA_USERNAME }}
+          OSSRH_JIRA_PASSWORD: ${{ secrets.OSSRH_JIRA_PASSWORD }}

--- a/.github/workflows/source-release-draft.yml
+++ b/.github/workflows/source-release-draft.yml
@@ -1,0 +1,125 @@
+name: Build Source Release Draft
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-source-release-draft:
+    if: ${{ github.repository == 'apache/casbin-jcasbin' && !contains(github.ref_name, '-') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute release metadata
+        id: release
+        run: |
+          TAG_NAME="${GITHUB_REF_NAME}"
+          if ! [[ "${TAG_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Unsupported release tag: ${TAG_NAME}" >&2
+            exit 1
+          fi
+
+          VERSION="${TAG_NAME#v}"
+          BASENAME="jcasbin-${VERSION}-src"
+          PREVIOUS_TAG="$(
+            git tag --list 'v*' |
+              grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' |
+              sort -V |
+              awk -v current="${TAG_NAME}" '
+                $0 == current {
+                  print previous
+                  exit
+                }
+                {
+                  previous = $0
+                }
+              '
+          )"
+
+          echo "tag=${TAG_NAME}" >> "${GITHUB_OUTPUT}"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "basename=${BASENAME}" >> "${GITHUB_OUTPUT}"
+          echo "previous_tag=${PREVIOUS_TAG}" >> "${GITHUB_OUTPUT}"
+
+      - name: Generate release notes
+        run: |
+          CURRENT_TAG="${{ steps.release.outputs.tag }}"
+          CURRENT_VERSION="${{ steps.release.outputs.version }}"
+          PREVIOUS_TAG="${{ steps.release.outputs.previous_tag }}"
+          RELEASE_DATE="$(date -u +%F)"
+          RANGE="${CURRENT_TAG}"
+
+          if [ -n "${PREVIOUS_TAG}" ]; then
+            RANGE="${PREVIOUS_TAG}..${CURRENT_TAG}"
+          fi
+
+          FEATURES="$(git log --pretty=format:'%s (%h)' "${RANGE}" | grep -Ei '^(feat)(\(.+\))?: ' || true)"
+          FIXES="$(git log --pretty=format:'%s (%h)' "${RANGE}" | grep -Ei '^(fix)(\(.+\))?: ' || true)"
+          DOCS="$(git log --pretty=format:'%s (%h)' "${RANGE}" | grep -Ei '^(docs?|doc)(\(.+\))?: ' || true)"
+
+          {
+            if [ -n "${PREVIOUS_TAG}" ]; then
+              echo "# [${CURRENT_VERSION}](https://github.com/${GITHUB_REPOSITORY}/compare/${PREVIOUS_TAG}...${CURRENT_TAG}) (${RELEASE_DATE})"
+            else
+              echo "# ${CURRENT_VERSION} (${RELEASE_DATE})"
+            fi
+            echo
+            echo "This GitHub release is a draft helper for packaging and release notes."
+            echo
+            if [ -n "${PREVIOUS_TAG}" ]; then
+              echo "Changes since ${PREVIOUS_TAG}."
+            fi
+            echo
+
+            if [ -n "${FEATURES}" ]; then
+              echo "## Features"
+              echo
+              printf '%s\n' "${FEATURES}" | sed 's/^/- /'
+              echo
+            fi
+
+            if [ -n "${FIXES}" ]; then
+              echo "## Fixes"
+              echo
+              printf '%s\n' "${FIXES}" | sed 's/^/- /'
+              echo
+            fi
+
+            if [ -n "${DOCS}" ]; then
+              echo "## Docs"
+              echo
+              printf '%s\n' "${DOCS}" | sed 's/^/- /'
+              echo
+            fi
+
+            if [ -z "${FEATURES}${FIXES}${DOCS}" ]; then
+              echo "## Notes"
+              echo
+              echo "- No feat/fix/doc commits were found in this release range."
+            fi
+          } > RELEASE_NOTES.md
+
+      - name: Create source archives
+        run: |
+          mkdir -p dist
+          git archive --format=tar.gz --prefix="${{ steps.release.outputs.basename }}/" -o "dist/${{ steps.release.outputs.basename }}.tar.gz" "${{ steps.release.outputs.tag }}"
+          git archive --format=zip --prefix="${{ steps.release.outputs.basename }}/" -o "dist/${{ steps.release.outputs.basename }}.zip" "${{ steps.release.outputs.tag }}"
+
+      - name: Create draft GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.release.outputs.tag }}
+          name: JCasbin ${{ steps.release.outputs.tag }}
+          body_path: RELEASE_NOTES.md
+          draft: true
+          files: |
+            dist/${{ steps.release.outputs.basename }}.tar.gz
+            dist/${{ steps.release.outputs.basename }}.zip

--- a/.github/workflows/source-snapshot.yml
+++ b/.github/workflows/source-snapshot.yml
@@ -1,0 +1,139 @@
+name: Build Source Snapshot
+
+on:
+  workflow_run:
+    workflows:
+      - build
+    types:
+      - completed
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-source-snapshot:
+    if: ${{ github.repository == 'apache/casbin-jcasbin' && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Compute snapshot metadata
+        id: snapshot
+        run: |
+          LATEST_RELEASE_TAG="$(
+            git tag --list 'v*' |
+              grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' |
+              sort -V |
+              tail -n 1
+          )"
+
+          if [ -z "${LATEST_RELEASE_TAG}" ]; then
+            BASE_VERSION="0.1.0"
+          else
+            RELEASE_VERSION="${LATEST_RELEASE_TAG#v}"
+            MAJOR="${RELEASE_VERSION%%.*}"
+            REST="${RELEASE_VERSION#*.}"
+            MINOR="${REST%%.*}"
+            NEXT_MINOR="$((MINOR + 1))"
+            BASE_VERSION="${MAJOR}.${NEXT_MINOR}.0"
+          fi
+
+          ESCAPED_BASE_VERSION="${BASE_VERSION//./\\.}"
+          LAST_SNAPSHOT_NUMBER="$(
+            git tag --list "v${BASE_VERSION}-snapshot.*" |
+              sed -nE "s/^v${ESCAPED_BASE_VERSION}-snapshot\\.([0-9]+)$/\\1/p" |
+              sort -n |
+              tail -n 1
+          )"
+          LAST_SNAPSHOT_NUMBER="${LAST_SNAPSHOT_NUMBER:-0}"
+          NEXT_SNAPSHOT_NUMBER="$((LAST_SNAPSHOT_NUMBER + 1))"
+          SNAPSHOT_VERSION="v${BASE_VERSION}-snapshot.${NEXT_SNAPSHOT_NUMBER}"
+          BASENAME="jcasbin-${SNAPSHOT_VERSION#v}-src"
+
+          echo "latest_release_tag=${LATEST_RELEASE_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "base_version=${BASE_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "number=${NEXT_SNAPSHOT_NUMBER}" >> "${GITHUB_OUTPUT}"
+          echo "version=${SNAPSHOT_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "basename=${BASENAME}" >> "${GITHUB_OUTPUT}"
+          if [ -n "${LAST_SNAPSHOT_NUMBER}" ] && [ "${LAST_SNAPSHOT_NUMBER}" -gt 0 ]; then
+            echo "previous_tag=v${BASE_VERSION}-snapshot.${LAST_SNAPSHOT_NUMBER}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "previous_tag=${LATEST_RELEASE_TAG}" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Generate snapshot release notes
+        run: |
+          PREVIOUS_TAG="${{ steps.snapshot.outputs.previous_tag }}"
+          CURRENT_TAG="${{ steps.snapshot.outputs.version }}"
+          CURRENT_VERSION="${CURRENT_TAG#v}"
+          RELEASE_DATE="$(date -u +%F)"
+          RANGE="HEAD"
+
+          if [ -n "${PREVIOUS_TAG}" ]; then
+            RANGE="${PREVIOUS_TAG}..HEAD"
+          fi
+
+          FEATURES="$(git log --pretty=format:'%s (%h)' "${RANGE}" | grep -Ei '^(feat)(\(.+\))?: ' || true)"
+          FIXES="$(git log --pretty=format:'%s (%h)' "${RANGE}" | grep -Ei '^(fix)(\(.+\))?: ' || true)"
+          DOCS="$(git log --pretty=format:'%s (%h)' "${RANGE}" | grep -Ei '^(docs?|doc)(\(.+\))?: ' || true)"
+
+          {
+            if [ -n "${PREVIOUS_TAG}" ]; then
+              echo "# [${CURRENT_VERSION}](https://github.com/${GITHUB_REPOSITORY}/compare/${PREVIOUS_TAG}...${CURRENT_TAG}) (${RELEASE_DATE})"
+            else
+              echo "# ${CURRENT_VERSION} (${RELEASE_DATE})"
+            fi
+            echo
+            if [ -n "${FEATURES}" ]; then
+              echo "## Features"
+              echo
+              printf '%s\n' "${FEATURES}" | sed 's/^/- /'
+              echo
+            fi
+
+            if [ -n "${FIXES}" ]; then
+              echo "## Fixes"
+              echo
+              printf '%s\n' "${FIXES}" | sed 's/^/- /'
+              echo
+            fi
+
+            if [ -n "${DOCS}" ]; then
+              echo "## Docs"
+              echo
+              printf '%s\n' "${DOCS}" | sed 's/^/- /'
+              echo
+            fi
+
+            if [ -z "${FEATURES}${FIXES}${DOCS}" ]; then
+              echo "## Notes"
+              echo
+              echo "- No feat/fix/doc commits were found in this snapshot range."
+            fi
+          } > SNAPSHOT_RELEASE_NOTES.md
+
+      - name: Create source archives
+        run: |
+          mkdir -p dist
+          git archive --format=tar.gz --prefix="${{ steps.snapshot.outputs.basename }}/" -o "dist/${{ steps.snapshot.outputs.basename }}.tar.gz" HEAD
+          git archive --format=zip --prefix="${{ steps.snapshot.outputs.basename }}/" -o "dist/${{ steps.snapshot.outputs.basename }}.zip" HEAD
+
+      - name: Create snapshot GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.snapshot.outputs.version }}
+          target_commitish: ${{ github.event.workflow_run.head_sha || github.sha }}
+          name: ${{ steps.snapshot.outputs.version }}
+          body_path: SNAPSHOT_RELEASE_NOTES.md
+          draft: false
+          prerelease: true
+          files: |
+            dist/${{ steps.snapshot.outputs.basename }}.tar.gz
+            dist/${{ steps.snapshot.outputs.basename }}.zip

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
-            <url>https://central.sonatype.com</url>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
 
@@ -130,7 +130,7 @@
                 <!-- Automatically close and deploy from OSSRH -->
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.6.0</version>
+                <version>0.9.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>ossrh</publishingServerId>


### PR DESCRIPTION
After a PR is merged into master:

  - The build workflow runs Maven tests and coverage.
  - If build succeeds, the Maven snapshot workflow runs.
  - It finds the latest formal tag, for example v1.99.0.
  - It computes the next minor snapshot version, for example 1.100.0-SNAPSHOT.
  - It deploys that artifact to the Sonatype snapshot repository (maven).
  - The source snapshot workflow also runs after build succeeds.
  - It creates a GitHub prerelease like v1.100.0-snapshot.1, v1.100.0-snapshot.2, etc.
  - Snapshot release notes are incremental from the previous snapshot tag.